### PR TITLE
Adding CONFIG_ENVIROMNEMT parameter

### DIFF
--- a/utils/deploy-manager.js
+++ b/utils/deploy-manager.js
@@ -16,7 +16,7 @@ const defaultConfigs = {
 class DeployManager {
     constructor(network) {
         this.network = network;
-
+        this.env = process.env.CONFIG_ENVIRONMENT
         const suffixes = (process.env.S3_BUCKET_SUFFIXES || "").split(':');
 
         // config
@@ -26,7 +26,8 @@ class DeployManager {
             const key = process.env.S3_CONFIG_KEY;
             configLoader = new ConfiguratorLoader.S3(bucket, key);
         } else {
-            const filePath = path.join(__dirname, './config', `${this.network}.json`)
+            const fileName = this.env ? `${this.network}.${this.env}.json` : `${this.network}.json`
+            const filePath = path.join(__dirname, './config', fileName)
             configLoader = new ConfiguratorLoader.Local(filePath)
         }
         this.configurator = new Configurator(configLoader);
@@ -76,7 +77,7 @@ class DeployManager {
             this.versionUploader = new VersionUploader.S3(config.settings.versionUpload.bucket, config.settings.versionUpload.url);
         } else {
             const dirPath = path.join(__dirname, './versions/', this.network);
-            this.versionUploader = new VersionUploader.Local(dirPath);
+            this.versionUploader = new VersionUploader.Local(dirPath, this.env);
         }
     }
 }

--- a/utils/version-uploader.js
+++ b/utils/version-uploader.js
@@ -40,8 +40,9 @@ class VersionUploaderS3 {
 
 class VersionUploaderLocal{
 
-    constructor(dir) {
+    constructor(dir, env) {
         this._dir = dir;
+        this._env = env;
     }
 
     async upload(version) { 
@@ -55,7 +56,7 @@ class VersionUploaderLocal{
     }
 
     _path() {
-        return path.join(this._dir, `latest.json`);
+        return path.join(this._dir, this._env ? `${this._env}.latest.json` : `latest.json`);
     }
 }
 


### PR DESCRIPTION
Adding `CONFIG_ENVIROMNEMT` env variable, so multiple environments can be deployed on the same network without overriding each other.

For example
`CONFIG_ENVIRONMENT=qa etherlime deploy --file deployment/2_deploy_contracts.js --network ganache`

will use the config: `utils/config/ganache.qa.json`