### PR TITLE
Add Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,47 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
-version: 2.1
-# Use a package of configuration called an orb.
-orbs:
-  # Declare a dependency on the welcome-orb
-  welcome: circleci/welcome-orb@0.4.1
-# Orchestrate or schedule a set of jobs
+version: 2
+
+job_common: &job_common
+  docker:
+    - image: circleci/node:10.12-stretch
+  working_directory: ~/argent-contracts
+step_save_cache: &step_save_cache
+  save_cache:
+    paths:
+      - ~/.cache/package-lock
+    key: node-modules-{{ checksum "package-lock.json" }}
+step_restore_cache: &step_restore_cache
+  restore_cache:
+    keys:
+      - node-modules-{{ checksum "package-lock.json" }}
+step_setup_global_packages: &step_setup_global_packages
+  run:
+    name: "Set up global packages"
+    command: |
+      npm install
+
+jobs:
+  unit-test:
+    <<: *job_common
+    steps:
+      - checkout
+      - <<: *step_restore_cache
+      - <<: *step_setup_global_packages
+      - run:
+          name: "Compiling contracts"
+          command: npm run compile
+      - run:
+          name: "Running unit tests"
+          command: npm run ganache >/dev/null 2>&1 & npm run test
+
+      - <<: *step_save_cache
+      # Save test results to artifacts
+      - store_test_results:
+          path: test-results.xml
+      - store_artifacts:
+          path: test-results.xml
+
 workflows:
-  # Name the workflow "welcome"
-  welcome:
-    # Run the welcome/run job in its own container
+  version: 2
+  commit:
     jobs:
-      - welcome/run
+      - unit-test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "test"
   },
   "scripts": {
-    "compile": "npx etherlime compile --runs=200",
+    "compile": "npx etherlime compile --runs=999",
     "ganache": "npx etherlime ganache --gasLimit=10700000 -e 10000",
     "test": "npx etherlime test --skip-compilation",
     "ctest": "npm run compile && npm run test"


### PR DESCRIPTION
As a way of safeguarding the repo, we add Circle CI, see https://app.circleci.com/github/argentlabs/argent-contracts/pipelines

Currently this only runs the unit tests, but the plan is to extend it to include linting, integration testing, security testing, gas cost reporting, code coverage checks and more.

Following the merge here, we will mandate all checks pass before merging to release branches, e.g. `develop`.