### PR TITLE
Add deployment script checks to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,9 @@ jobs:
       - run:
           name: "Running unit tests"
           command: npm run ganache >/dev/null 2>&1 & npm run test
-
+      - run:
+          name: "Testing deployment scripts"
+          command: npm run ganache >/dev/null 2>&1 & npm run test:deployment
       - <<: *step_save_cache
       # Save test results to artifacts
       - store_test_results:

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,6 +30,9 @@ fi
 
 for IDX in "$@"
 do
-    FILE=`ls deployment/${IDX}_*.js`
+    FILE=`ls ./deployment/${IDX}_*.js`
     npx etherlime deploy --file $FILE --network $NETWORK --compile false
+    if [ $? -ne 0 ]; then
+        exit 1 # exit with failure status
+    fi
 done

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Usage: ./deploy.sh [network] [aws-profile-suffix] [...steps]
+#        ./deploy.sh [network] [...steps] (if network == aws-profile-suffix)
+#
+# Examples: ./deploy.sh dev 1 2 3 4
+#           ./deploy.sh ganache 1 2 3 4 5 6
+#           ./deploy.sh ropsten dev 5 6
+
+
+set -e # stop the script if any subprocess fails
+
+NETWORK=$1
+shift
+
+re='^[0-9]+$'
+if [[ $1 =~ $re ]] ; then
+    PROFILE=$NETWORK
+else
+    PROFILE=$1
+    shift
+fi
+
+npx etherlime compile --runs 999
+
+if [ $NETWORK -ne 'ganache' ]; then
+    AWS_PROFILE=argent-$PROFILE
+    AWS_SDK_LOAD_CONFIG=true
+fi
+
+for IDX in "$@"
+do
+    FILE=`ls deployment/${IDX}_*.js`
+    npx etherlime deploy --file $FILE --network $NETWORK --compile false
+done

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,15 +23,10 @@ fi
 
 npx etherlime compile --runs 999
 
-if [ $NETWORK -ne 'ganache' ]; then
-    AWS_PROFILE=argent-$PROFILE
-    AWS_SDK_LOAD_CONFIG=true
-fi
-
 for IDX in "$@"
 do
     FILE=`ls ./deployment/${IDX}_*.js`
-    npx etherlime deploy --file $FILE --network $NETWORK --compile false
+    AWS_PROFILE=argent-$PROFILE AWS_SDK_LOAD_CONFIG=true npx etherlime deploy --file $FILE --network $NETWORK --compile false
     if [ $? -ne 0 ]; then
         exit 1 # exit with failure status
     fi

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "npx etherlime test --skip-compilation",
     "ctest": "npm run compile && npm run test",
     "lint:contracts": "npx ethlint --dir .",
-    "ethlint-staged": "bash ./scripts/ethlint.sh"
+    "ethlint-staged": "bash ./scripts/ethlint.sh",
+    "test:deployment": "./deploy.sh ganache `seq 1 7`"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Add deployment script checks to Circle CI to run each deployment script against the local test environment instance as a way of ensuring end-to-end environment setup is correct. Atm this is done manually and prone to errors.