### PR TITLE
Transfer wallet ownership and recovery mode improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 build
 tmp
 bin
+.outputParameter
 
 ## Core latex/pdflatex auxiliary files:
 *.aux

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -147,7 +147,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
      */
     function cancelRecovery(BaseWallet _wallet) external onlyExecute onlyWhenRecovery(_wallet) {
         RecoveryConfig storage config = recoveryConfigs[address(_wallet)];
-        emit  RecoveryCanceled(address(_wallet), config.recovery);
+        emit RecoveryCanceled(address(_wallet), config.recovery);
         guardianStorage.setLock(_wallet, 0);
         delete recoveryConfigs[address(_wallet)];
     }
@@ -232,7 +232,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
                 } // "RM: signatures not valid"
             }
             return true;
-        } else {
+        } else if (functionSignature == CANCEL_RECOVERY_PREFIX) {
             // Owner MIGHT sign
             for (uint8 i = 0; i < _signatures.length / 65; i++) {
                 address signer = recoverSigner(_signHash, _signatures, i);

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -37,7 +37,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
     bytes4 constant internal EXECUTE_RECOVERY_PREFIX = bytes4(keccak256("executeRecovery(address,address)"));
     bytes4 constant internal FINALIZE_RECOVERY_PREFIX = bytes4(keccak256("finalizeRecovery(address)"));
     bytes4 constant internal CANCEL_RECOVERY_PREFIX = bytes4(keccak256("cancelRecovery(address)"));
-    bytes4 constant internal EXECUTE_OWNERSHIP_TRANSFER_PREFIX = bytes4(keccak256("executeOwnershipTransfer(address,address)"));
+    bytes4 constant internal TRANSFER_OWNERSHIP_PREFIX = bytes4(keccak256("transferOwnership(address,address)"));
 
     struct RecoveryConfig {
         address recovery;
@@ -168,7 +168,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
      * @param _wallet The target wallet.
      * @param _newOwner The address to which ownership should be transferred.
      */
-    function executeOwnershipTransfer(
+    function transferOwnership(
         BaseWallet _wallet,
         address _newOwner
     )
@@ -197,7 +197,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
         bool isGuardian = false;
 
         bytes4 functionSignature = functionPrefix(_data);
-        if (functionSignature == EXECUTE_OWNERSHIP_TRANSFER_PREFIX) {
+        if (functionSignature == TRANSFER_OWNERSHIP_PREFIX) {
             // Owner SHOULD sign
             for (uint8 i = 0; i < _signatures.length / 65; i++) {
                 address signer = recoverSigner(_signHash, _signatures, i);
@@ -265,7 +265,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
         if (methodId == CANCEL_RECOVERY_PREFIX) {
             return SafeMath.ceil(recoveryConfigs[address(_wallet)].guardianCount + 1, 2);
         }
-        if (methodId == EXECUTE_OWNERSHIP_TRANSFER_PREFIX) {
+        if (methodId == TRANSFER_OWNERSHIP_PREFIX) {
             uint majorityGuardians = SafeMath.ceil(guardianStorage.guardianCount(_wallet), 2);
             return SafeMath.add(majorityGuardians, 1);
         }

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -51,18 +51,18 @@ contract RecoveryManager is BaseModule, RelayerModule {
         Disallowed
     }
 
-    // the wallet specific storage
+    // Wallet specific storage
     mapping (address => RecoveryConfig) internal recoveryConfigs;
 
     // Recovery period
     uint256 public recoveryPeriod;
     // Lock period
     uint256 public lockPeriod;
-    // The security period used for (non-recovery) ownership transfer
+    // Security period used for (non-recovery) ownership transfer
     uint256 public securityPeriod;
-    // the security window used for (non-recovery) ownership transfer
+    // Security window used for (non-recovery) ownership transfer
     uint256 public securityWindow;
-    // location of the Guardian storage
+    // Location of the Guardian storage
     GuardianStorage public guardianStorage;
 
     // *************** Events *************************** //
@@ -199,23 +199,23 @@ contract RecoveryManager is BaseModule, RelayerModule {
 
         bytes4 functionSignature = functionPrefix(_data);
         if (functionSignature == TRANSFER_OWNERSHIP_PREFIX) {
-            // Owner SHOULD sign
+            // Owner MUST sign
             for (uint8 i = 0; i < _signatures.length / 65; i++) {
                 address signer = recoverSigner(_signHash, _signatures, i);
                 if (i == 0) {
-                    // AT: first signer must be owner
+                    // First signer must be owner
                     if (!isOwner(_wallet, signer)) {
                         return false;
                     }
                 } else {
                     if (signer <= lastSigner) {
                         return false;
-                    } // "RM: signers must be different"
+                    } // Signers must be different
                     lastSigner = signer;
                     (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
                     if (!isGuardian) {
                         return false;
-                    } // "RM: signatures not valid"
+                    } // Signature not valid
                 }
             }
             return true;
@@ -225,12 +225,12 @@ contract RecoveryManager is BaseModule, RelayerModule {
                 address signer = recoverSigner(_signHash, _signatures, i);
                 if (signer <= lastSigner) {
                     return false;
-                } // "RM: signers must be different"
+                } // Signers must be different
                 lastSigner = signer;
                 (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
                 if (!isGuardian) {
                     return false;
-                } // "RM: signatures not valid"
+                } // Signature not valid
             }
             return true;
         } else if (functionSignature == CANCEL_RECOVERY_PREFIX) {
@@ -238,17 +238,17 @@ contract RecoveryManager is BaseModule, RelayerModule {
             for (uint8 i = 0; i < _signatures.length / 65; i++) {
                 address signer = recoverSigner(_signHash, _signatures, i);
                 if (i == 0 && isOwner(_wallet, signer)) {
-                    // first signer can be owner
+                    // First signer can be owner
                     continue;
                 } else {
                     if (signer <= lastSigner) {
                         return false;
-                    } // "RM: signers must be different"
+                    } // Signers must be different
                     lastSigner = signer;
                     (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
                     if (!isGuardian) {
                         return false;
-                    } // "RM: signatures not valid"
+                    } // Signature not valid
                 }
             }
             return true;
@@ -269,38 +269,38 @@ contract RecoveryManager is BaseModule, RelayerModule {
         bool isGuardian = false;
 
         if (_option == OwnerSignature.Required) {
-            // Owner SHOULD sign
+            // Owner MUST sign
             for (uint8 i = 0; i < _signatures.length / 65; i++) {
                 address signer = recoverSigner(_signHash, _signatures, i);
                 if (i == 0) {
-                    // AT: first signer must be owner
+                    // First signer must be owner
                     if (!isOwner(_wallet, signer)) {
                         return false;
                     }
                 } else {
                     if (signer <= lastSigner) {
                         return false;
-                    } // "RM: signers must be different"
+                    } // Signers must be different"
                     lastSigner = signer;
                     (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
                     if (!isGuardian) {
                         return false;
-                    } // "RM: signatures not valid"
+                    } // Signature not valid
                 }
             }
             return true;
         } else if (_option == OwnerSignature.Disallowed) {
-            // Owner is NOT allowed to sign
+            // Owner MUST NOT sign
             for (uint8 i = 0; i < _signatures.length / 65; i++) {
                 address signer = recoverSigner(_signHash, _signatures, i);
                 if (signer <= lastSigner) {
                     return false;
-                } // "RM: signers must be different"
+                } // Signers must be different"
                 lastSigner = signer;
                 (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
                 if (!isGuardian) {
                     return false;
-                } // "RM: signatures not valid"
+                } // Signature not valid"
             }
             return true;
         } else if (_option == OwnerSignature.Optional) {
@@ -308,17 +308,17 @@ contract RecoveryManager is BaseModule, RelayerModule {
             for (uint8 i = 0; i < _signatures.length / 65; i++) {
                 address signer = recoverSigner(_signHash, _signatures, i);
                 if (i == 0 && isOwner(_wallet, signer)) {
-                    // first signer can be owner
+                    // First signer can be owner
                     continue;
                 } else {
                     if (signer <= lastSigner) {
                         return false;
-                    } // "RM: signers must be different"
+                    } // Signers must be different
                     lastSigner = signer;
                     (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
                     if (!isGuardian) {
                         return false;
-                    } // "RM: signatures not valid"
+                    } // Signature not valid
                 }
             }
             return true;

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -195,23 +195,47 @@ contract RecoveryManager is BaseModule, RelayerModule {
         address lastSigner = address(0);
         address[] memory guardians = guardianStorage.getGuardians(_wallet);
         bool isGuardian = false;
-        for (uint8 i = 0; i < _signatures.length / 65; i++) {
-            address signer = recoverSigner(_signHash, _signatures, i);
-            if (i == 0 && isOwner(_wallet, signer)) {
-                // first signer can be owner
-                continue;
-            } else {
-                if (signer <= lastSigner) {
-                    return false;
-                } // "RM: signers must be different"
-                lastSigner = signer;
-                (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
-                if (!isGuardian) {
-                    return false;
-                } // "RM: signatures not valid"
+
+        bytes4 functionSignature = functionPrefix(_data);
+        if (functionSignature == EXECUTE_OWNERSHIP_TRANSFER_PREFIX) {
+            for (uint8 i = 0; i < _signatures.length / 65; i++) {
+                address signer = recoverSigner(_signHash, _signatures, i);
+                if (i == 0) {
+                    // AT: first signer must be owner
+                    if (!isOwner(_wallet, signer)) {
+                        return false;
+                    }
+                } else {
+                    if (signer <= lastSigner) {
+                        return false;
+                    } // "RM: signers must be different"
+                    lastSigner = signer;
+                    (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
+                    if (!isGuardian) {
+                        return false;
+                    } // "RM: signatures not valid"
+                }
             }
+            return true;
+        } else {
+            for (uint8 i = 0; i < _signatures.length / 65; i++) {
+                address signer = recoverSigner(_signHash, _signatures, i);
+                if (i == 0 && isOwner(_wallet, signer)) {
+                    // first signer can be owner
+                    continue;
+                } else {
+                    if (signer <= lastSigner) {
+                        return false;
+                    } // "RM: signers must be different"
+                    lastSigner = signer;
+                    (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
+                    if (!isGuardian) {
+                        return false;
+                    } // "RM: signatures not valid"
+                }
+            }
+            return true;
         }
-        return true;
     }
 
     function getRequiredSignatures(BaseWallet _wallet, bytes memory _data) internal view returns (uint256) {
@@ -227,7 +251,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
         }
         if (methodId == EXECUTE_OWNERSHIP_TRANSFER_PREFIX) {
             uint majorityGuardians = SafeMath.ceil(guardianStorage.guardianCount(_wallet), 2);
-            return 1 + majorityGuardians;
+            return SafeMath.add(majorityGuardians, 1);
         }
         if (methodId == FINALIZE_OWNERSHIP_TRANSFER_PREFIX) {
             return 0;

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -173,12 +173,10 @@ contract RecoveryManager is BaseModule, RelayerModule {
     )
         external
         onlyExecute
-        //? onlyWhenUnlocked(_wallet)
+        onlyWhenUnlocked(_wallet)
     {
         require(_newOwner != address(0), "RM: new owner address cannot be null");
-        OwnershipTransferConfig storage config = ownershipTransferConfigs[address(_wallet)];
-        config.newOwner = _newOwner;
-        config.executeAfter = uint64(now + securityPeriod);
+        _wallet.setOwner(_newOwner);
 
         emit OwnershipTransferExecuted(address(_wallet), _newOwner, config.executeAfter);
     }
@@ -227,7 +225,8 @@ contract RecoveryManager is BaseModule, RelayerModule {
             return SafeMath.ceil(recoveryConfigs[address(_wallet)].guardianCount + 1, 2);
         }
         if (methodId == EXECUTE_OWNERSHIP_TRANSFER_PREFIX) {
-            return 1;
+            uint majorityGuardians = SafeMath.ceil(guardianStorage.guardianCount(_wallet), 2);
+            return 1 + majorityGuardians;
         }
         if (methodId == FINALIZE_OWNERSHIP_TRANSFER_PREFIX) {
             return 0;

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -164,10 +164,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
      * @param _wallet The target wallet.
      * @param _newOwner The address to which ownership should be transferred.
      */
-    function transferOwnership(BaseWallet _wallet, address _newOwner) external
-    onlyExecute
-    onlyWhenUnlocked(_wallet)
-    {
+    function transferOwnership(BaseWallet _wallet, address _newOwner) external onlyExecute onlyWhenUnlocked(_wallet) {
         require(_newOwner != address(0), "RM: new owner address cannot be null");
         _wallet.setOwner(_newOwner);
 

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -193,77 +193,23 @@ contract RecoveryManager is BaseModule, RelayerModule {
     )
         internal view returns (bool)
     {
-        address lastSigner = address(0);
-        address[] memory guardians = guardianStorage.getGuardians(_wallet);
-        bool isGuardian = false;
-
         bytes4 functionSignature = functionPrefix(_data);
         if (functionSignature == TRANSFER_OWNERSHIP_PREFIX) {
-            // Owner MUST sign
-            for (uint8 i = 0; i < _signatures.length / 65; i++) {
-                address signer = recoverSigner(_signHash, _signatures, i);
-                if (i == 0) {
-                    // First signer must be owner
-                    if (!isOwner(_wallet, signer)) {
-                        return false;
-                    }
-                } else {
-                    if (signer <= lastSigner) {
-                        return false;
-                    } // Signers must be different
-                    lastSigner = signer;
-                    (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
-                    if (!isGuardian) {
-                        return false;
-                    } // Signature not valid
-                }
-            }
-            return true;
+            return validateSignatures(_wallet, _signHash, _signatures, OwnerSignature.Required);
         } else if (functionSignature == EXECUTE_RECOVERY_PREFIX) {
-            // Owner is NOT allowed to sign
-            for (uint8 i = 0; i < _signatures.length / 65; i++) {
-                address signer = recoverSigner(_signHash, _signatures, i);
-                if (signer <= lastSigner) {
-                    return false;
-                } // Signers must be different
-                lastSigner = signer;
-                (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
-                if (!isGuardian) {
-                    return false;
-                } // Signature not valid
-            }
-            return true;
+            return validateSignatures(_wallet, _signHash, _signatures, OwnerSignature.Disallowed);
         } else if (functionSignature == CANCEL_RECOVERY_PREFIX) {
-            // Owner MIGHT sign
-            for (uint8 i = 0; i < _signatures.length / 65; i++) {
-                address signer = recoverSigner(_signHash, _signatures, i);
-                if (i == 0 && isOwner(_wallet, signer)) {
-                    // First signer can be owner
-                    continue;
-                } else {
-                    if (signer <= lastSigner) {
-                        return false;
-                    } // Signers must be different
-                    lastSigner = signer;
-                    (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
-                    if (!isGuardian) {
-                        return false;
-                    } // Signature not valid
-                }
-            }
-            return true;
+            return validateSignatures(_wallet, _signHash, _signatures, OwnerSignature.Optional);
         }
     }
 
     function validateSignatures(
         BaseWallet _wallet,
-        bytes memory _data,
         bytes32 _signHash,
         bytes memory _signatures,
         OwnerSignature _option
     ) internal view returns (bool)
     {
-
         address lastSigner = address(0);
         address[] memory guardians = guardianStorage.getGuardians(_wallet);
         bool isGuardian = false;

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -64,6 +64,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
     event RecoveryExecuted(address indexed _wallet, address indexed _recovery, uint64 executeAfter);
     event RecoveryFinalized(address indexed _wallet, address indexed _recovery);
     event RecoveryCanceled(address indexed _wallet, address indexed _recovery);
+    event OwnershipTransfered(address indexed _wallet, address indexed _newOwner);
 
     // *************** Modifiers ************************ //
 
@@ -178,7 +179,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
         require(_newOwner != address(0), "RM: new owner address cannot be null");
         _wallet.setOwner(_newOwner);
 
-        emit OwnershipTransferExecuted(address(_wallet), _newOwner, config.executeAfter);
+        emit OwnershipTransfered(address(_wallet), _newOwner);
     }
 
     // *************** Implementation of RelayerModule methods ********************* //

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -241,7 +241,7 @@ contract RecoveryManager is BaseModule, RelayerModule {
     function getRequiredSignatures(BaseWallet _wallet, bytes memory _data) internal view returns (uint256) {
         bytes4 methodId = functionPrefix(_data);
         if (methodId == EXECUTE_RECOVERY_PREFIX) {
-            return SafeMath.ceil(guardianStorage.guardianCount(_wallet) + 1, 2);
+            return SafeMath.ceil(guardianStorage.guardianCount(_wallet), 2);
         }
         if (methodId == FINALIZE_RECOVERY_PREFIX) {
             return 0;

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -62,6 +62,7 @@ describe("Test Approved Transfer", function () {
 
         for (const address of guardianAddresses) {
             await guardianManager.from(owner).addGuardian(wallet.contractAddress, address, { gasLimit: 500000 });
+            console.log("guardian added", address)
         }
 
         await manager.increaseTime(30);
@@ -70,6 +71,7 @@ describe("Test Approved Transfer", function () {
         }
         const count = (await guardianManager.guardianCount(wallet.contractAddress)).toNumber();
         assert.equal(count, guardians.length, `${guardians.length} guardians should be added`);
+
     }
 
     async function createSmartContractGuardians(guardians) {

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -62,7 +62,6 @@ describe("Test Approved Transfer", function () {
 
         for (const address of guardianAddresses) {
             await guardianManager.from(owner).addGuardian(wallet.contractAddress, address, { gasLimit: 500000 });
-            console.log("guardian added", address)
         }
 
         await manager.increaseTime(30);
@@ -71,7 +70,6 @@ describe("Test Approved Transfer", function () {
         }
         const count = (await guardianManager.guardianCount(wallet.contractAddress)).toNumber();
         assert.equal(count, guardians.length, `${guardians.length} guardians should be added`);
-
     }
 
     async function createSmartContractGuardians(guardians) {

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -261,6 +261,13 @@ describe("RecoveryManager", function () {
     })
 
     describe("Ownership Transfer", () => {
+        it("should not allow transfer to an empty address", async () => {
+            await addGuardians([guardian1]);
+            let txReceipt = await manager.relay(recoveryManager, 'transferOwnership', [wallet.contractAddress, ethers.constants.AddressZero], wallet, [owner, guardian1]);
+            const success = parseRelayReceipt(txReceipt);
+            assert.isNotOk(success, "transferOwnership should fail");
+        });
+
         describe("Guardians: G = 1", () => {
             beforeEach(async () => {
                 await addGuardians([guardian1]);

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -8,7 +8,7 @@ const Registry = require("../build/ModuleRegistry");
 const TestManager = require("../utils/test-manager");
 const { sortWalletByAddress, parseRelayReceipt } = require("../utils/utilities.js");
 
-describe("RecoveryManager", function () {
+describe.only("RecoveryManager", function () {
     this.timeout(10000);
 
     const manager = new TestManager(accounts);
@@ -64,15 +64,15 @@ describe("RecoveryManager", function () {
     }
 
     function testExecuteRecovery(guardians) {
-        it("should let a majority of guardians execute the recovery procedure (relayed transaction)", async () => {
-            let majority = guardians.slice(0, Math.ceil((guardians.length + 1) / 2));
+        it("should let a majority of guardians execute the recovery procedure", async () => {
+            let majority = guardians.slice(0, Math.ceil((guardians.length) / 2));
             await manager.relay(recoveryManager, 'executeRecovery', [wallet.contractAddress, newowner.address], wallet, sortWalletByAddress(majority));
             const isLocked = await lockManager.isLocked(wallet.contractAddress);
             assert.isTrue(isLocked, "should be locked by recovery");
         });
 
-        it("should not let a minority of guardians execute the recovery procedure (relayed transaction)", async () => {
-            let minority = guardians.slice(0, Math.ceil((guardians.length + 1) / 2) - 1);
+        it("should not let a minority of guardians execute the recovery procedure", async () => {
+            let minority = guardians.slice(0, Math.ceil((guardians.length) / 2) - 1);
             let txReceipt = await manager.relay(recoveryManager, 'executeRecovery', [wallet.contractAddress, newowner.address], wallet, sortWalletByAddress(minority));
             const success = parseRelayReceipt(txReceipt);
             assert.isNotOk(success, "executeRecovery should fail");
@@ -82,7 +82,7 @@ describe("RecoveryManager", function () {
     }
 
     function testFinalizeRecovery() {
-        it("should let anyone finalize the recovery procedure after the recovery period (relayed transaction)", async () => {
+        it("should let anyone finalize the recovery procedure after the recovery period", async () => {
             await manager.increaseTime(40); // moving time to after the end of the recovery period
             await manager.relay(recoveryManager, 'finalizeRecovery', [wallet.contractAddress], wallet, []);
             const isLocked = await lockManager.isLocked(wallet.contractAddress);
@@ -91,7 +91,7 @@ describe("RecoveryManager", function () {
             assert.equal(walletOwner, newowner.address, "wallet owner should have been changed");
         });
 
-        it("should not let anyone finalize the recovery procedure before the end of the recovery period (relayed transaction)", async () => {
+        it("should not let anyone finalize the recovery procedure before the end of the recovery period", async () => {
             const txReceipt = await manager.relay(recoveryManager, 'finalizeRecovery', [wallet.contractAddress], wallet, []);
             const success = parseRelayReceipt(txReceipt);
             assert.isNotOk(success, 'finalization should have failed')
@@ -102,7 +102,7 @@ describe("RecoveryManager", function () {
     }
 
     function testCancelRecovery() {
-        it("should let 2 guardians cancel the recovery procedure (relayed transaction)", async () => {
+        it("should let 2 guardians cancel the recovery procedure", async () => {
             await manager.relay(recoveryManager, 'cancelRecovery', [wallet.contractAddress], wallet, sortWalletByAddress([guardian1, guardian2]));
             const isLocked = await lockManager.isLocked(wallet.contractAddress);
             assert.isFalse(isLocked, "should no longer be locked by recovery");
@@ -114,7 +114,7 @@ describe("RecoveryManager", function () {
             assert.equal(walletOwner, owner.address, "wallet owner should not have been changed");
         });
 
-        it("should let 1 guardian + owner cancel the recovery procedure (relayed transaction)", async () => {
+        it("should let 1 guardian + owner cancel the recovery procedure", async () => {
             await manager.relay(recoveryManager, 'cancelRecovery', [wallet.contractAddress], wallet, [owner, guardian1]);
             const isLocked = await lockManager.isLocked(wallet.contractAddress);
             assert.isFalse(isLocked, "should no longer be locked by recovery");
@@ -126,7 +126,7 @@ describe("RecoveryManager", function () {
             assert.equal(walletOwner, owner.address, "wallet owner should not have been changed");
         });
 
-        it("should not let 1 guardian cancel the recovery procedure (relayed transaction)", async () => {
+        it("should not let 1 guardian cancel the recovery procedure", async () => {
             let txReceipt = await manager.relay(recoveryManager, 'cancelRecovery', [wallet.contractAddress], wallet, [guardian1]);
             const success = parseRelayReceipt(txReceipt);
             assert.isNotOk(success, "cancelRecovery should fail");
@@ -134,7 +134,7 @@ describe("RecoveryManager", function () {
             assert.isTrue(isLocked, "should still be locked");
         });
 
-        it("should not let the owner cancel the recovery procedure (relayed transaction)", async () => {
+        it("should not let the owner cancel the recovery procedure", async () => {
             let txReceipt = await manager.relay(recoveryManager, 'cancelRecovery', [wallet.contractAddress], wallet, [owner]);
             const success = parseRelayReceipt(txReceipt);
             assert.isNotOk(success, "cancelRecovery should fail");

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -146,11 +146,6 @@ describe("RecoveryManager", function () {
     function testOwnershipTransfer(guardians) {
         it("should let owner + the majority of guardians execute an ownership transfer", async () => {
             const majority = guardians.slice(0, Math.ceil((guardians.length) / 2));
-            const gCount = await guardianStorage.guardianCount(wallet.contractAddress);
-            console.log("guardian count1", gCount.toString());
-
-            const count = await guardianManager.guardianCount(wallet.contractAddress);
-            console.log("guardian count2", count.toString());
 
             await manager.relay(recoveryManager, 'executeOwnershipTransfer', [wallet.contractAddress, newowner.address], wallet, [owner, ...sortWalletByAddress(majority)]);
             const walletOwner = await wallet.owner();
@@ -161,6 +156,17 @@ describe("RecoveryManager", function () {
             const minority = guardians.slice(0, Math.ceil((guardians.length) / 2) - 1);
 
             let txReceipt = await manager.relay(recoveryManager, 'executeOwnershipTransfer', [wallet.contractAddress, newowner.address], wallet, [owner, ...minority]);
+            const success = parseRelayReceipt(txReceipt);
+            assert.isNotOk(success, "executeOwnershipTransfer should fail");
+
+            const walletOwner = await wallet.owner();
+            assert.equal(walletOwner, owner.address, 'owner should not have been changed');
+        });
+
+        it("should not let majority of guardians execute an ownership transfer without owner", async () => {
+            const majority = guardians.slice(0, Math.ceil((guardians.length) / 2));
+            
+            let txReceipt = await manager.relay(recoveryManager, 'executeOwnershipTransfer', [wallet.contractAddress, newowner.address], wallet, [...majority]);
             const success = parseRelayReceipt(txReceipt);
             assert.isNotOk(success, "executeOwnershipTransfer should fail");
 

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -156,7 +156,7 @@ describe("RecoveryManager", function () {
         it("should let owner + the majority of guardians execute an ownership transfer", async () => {
             const majority = guardians.slice(0, Math.ceil((guardians.length) / 2));
 
-            await manager.relay(recoveryManager, 'executeOwnershipTransfer', [wallet.contractAddress, newowner.address], wallet, [owner, ...sortWalletByAddress(majority)]);
+            await manager.relay(recoveryManager, 'transferOwnership', [wallet.contractAddress, newowner.address], wallet, [owner, ...sortWalletByAddress(majority)]);
             const walletOwner = await wallet.owner();
             assert.equal(walletOwner, newowner.address, 'owner should have been changed');
         });
@@ -164,9 +164,9 @@ describe("RecoveryManager", function () {
         it("should not let owner + minority of guardians execute an ownership transfer", async () => {
             const minority = guardians.slice(0, Math.ceil((guardians.length) / 2) - 1);
 
-            let txReceipt = await manager.relay(recoveryManager, 'executeOwnershipTransfer', [wallet.contractAddress, newowner.address], wallet, [owner, ...minority]);
+            let txReceipt = await manager.relay(recoveryManager, 'transferOwnership', [wallet.contractAddress, newowner.address], wallet, [owner, ...minority]);
             const success = parseRelayReceipt(txReceipt);
-            assert.isNotOk(success, "executeOwnershipTransfer should fail");
+            assert.isNotOk(success, "transferOwnership should fail");
 
             const walletOwner = await wallet.owner();
             assert.equal(walletOwner, owner.address, 'owner should not have been changed');
@@ -175,9 +175,9 @@ describe("RecoveryManager", function () {
         it("should not let majority of guardians execute an ownership transfer without owner", async () => {
             const majority = guardians.slice(0, Math.ceil((guardians.length) / 2));
             
-            let txReceipt = await manager.relay(recoveryManager, 'executeOwnershipTransfer', [wallet.contractAddress, newowner.address], wallet, [...majority]);
+            let txReceipt = await manager.relay(recoveryManager, 'transferOwnership', [wallet.contractAddress, newowner.address], wallet, [...majority]);
             const success = parseRelayReceipt(txReceipt);
-            assert.isNotOk(success, "executeOwnershipTransfer should fail");
+            assert.isNotOk(success, "transferOwnership should fail");
 
             const walletOwner = await wallet.owner();
             assert.equal(walletOwner, owner.address, 'owner should not have been changed');

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -227,7 +227,7 @@ describe("RecoveryManager", function () {
             assert.equal(walletOwner, owner.address, 'owner should not have been changed.');
 
             await manager.increaseTime(48); // 42 == 2 * security_period
-            await assert.revert(recoveryManager.finalizeOwnershipTransfer(wallet.contractAddress), "confirming the ownership transfer should throw");
+            await assert.revertWith(recoveryManager.finalizeOwnershipTransfer(wallet.contractAddress), "RM: Too late to confirm ownership transfer");
 
             walletOwner = await wallet.owner();
             assert.equal(walletOwner, owner.address, 'owner should not have been changed.');
@@ -239,7 +239,7 @@ describe("RecoveryManager", function () {
             assert.equal(walletOwner, owner.address, 'owner should not have been changed.');
 
             await manager.increaseTime(48); // 42 == 2 * security_period
-            await assert.revert(recoveryManager.finalizeOwnershipTransfer(wallet.contractAddress), "confirming the ownership transfer should throw");
+            await assert.revertWith(recoveryManager.finalizeOwnershipTransfer(wallet.contractAddress), "RM: Too late to confirm ownership transfer");
 
             // second time
             await recoveryManager.from(owner).executeOwnershipTransfer(wallet.contractAddress, newowner.address);
@@ -253,7 +253,7 @@ describe("RecoveryManager", function () {
         });
 
         it("should only let the owner execute an ownership transfer (blockchain transaction)", async () => {
-            await assert.revert(recoveryManager.from(nonowner).executeOwnershipTransfer(wallet.contractAddress, newowner.address), "transferring ownership from nonowner should throw");
+            await assert.revertWith(recoveryManager.from(nonowner).executeOwnershipTransfer(wallet.contractAddress, newowner.address), "BM: must be an owner for the wallet");
         });
 
         it("should let the owner execute and finalize an ownership transfer (relayed transaction)", async () => {
@@ -270,14 +270,14 @@ describe("RecoveryManager", function () {
             await recoveryManager.from(owner).executeOwnershipTransfer(wallet.contractAddress, newowner.address);
             await recoveryManager.from(owner).cancelOwnershipTransfer(wallet.contractAddress);
             await manager.increaseTime(30);
-            await assert.revert(recoveryManager.finalizeOwnershipTransfer(wallet.contractAddress), "finalizeOwnershipTransfer should throw");
+            await assert.revert(recoveryManager.finalizeOwnershipTransfer(wallet.contractAddress), "RM: there must be an ongoing ownership transfer");
         });
 
         it("owner should be able to cancel pending ownership transfer (relayed transaction)", async () => {
             await manager.relay(recoveryManager, 'executeOwnershipTransfer', [wallet.contractAddress, newowner.address], wallet, [owner]);
             await manager.relay(recoveryManager, 'cancelOwnershipTransfer', [wallet.contractAddress], wallet, [owner]);
             await manager.increaseTime(30);
-            await assert.revert(recoveryManager.finalizeOwnershipTransfer(wallet.contractAddress), "finalizeOwnershipTransfer should throw");
+            await assert.revert(recoveryManager.finalizeOwnershipTransfer(wallet.contractAddress), "RM: there must be an ongoing ownership transfer");
         });
     });
 

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -262,7 +262,7 @@ describe("RecoveryManager", function () {
             testOwnershipTransfer([guardian1, guardian2]);
         });
 
-        describe.only("Guardians: G = 3", () => {
+        describe("Guardians: G = 3", () => {
             beforeEach(async () => {
                 await addGuardians([guardian1, guardian2, guardian3]);
             });

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -71,6 +71,15 @@ describe.only("RecoveryManager", function () {
             assert.isTrue(isLocked, "should be locked by recovery");
         });
 
+        it("should not let a majority of guardians and owner execute the recovery procedure", async () => {
+            let majority = guardians.slice(0, Math.ceil((guardians.length) / 2) - 1);
+            let txReceipt = await manager.relay(recoveryManager, 'executeRecovery', [wallet.contractAddress, newowner.address], wallet, [owner, ...sortWalletByAddress(majority)]);
+            const success = parseRelayReceipt(txReceipt);
+            assert.isNotOk(success, "executeRecovery should fail");
+            const isLocked = await lockManager.isLocked(wallet.contractAddress);
+            assert.isFalse(isLocked, "should not be locked");
+        });
+
         it("should not let a minority of guardians execute the recovery procedure", async () => {
             let minority = guardians.slice(0, Math.ceil((guardians.length) / 2) - 1);
             let txReceipt = await manager.relay(recoveryManager, 'executeRecovery', [wallet.contractAddress, newowner.address], wallet, sortWalletByAddress(minority));

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -8,7 +8,7 @@ const Registry = require("../build/ModuleRegistry");
 const TestManager = require("../utils/test-manager");
 const { sortWalletByAddress, parseRelayReceipt } = require("../utils/utilities.js");
 
-describe.only("RecoveryManager", function () {
+describe("RecoveryManager", function () {
     this.timeout(10000);
 
     const manager = new TestManager(accounts);


### PR DESCRIPTION
Here we remove old obsoleted logic for ownership transfer and introduce the following:

Wallet recovery updates:
- recovery signed by ceil(N/2) guardians
- cancel recovery signed by owner + floor(n/2) guardians

Transfer wallet ownership logic:
- signed by owner + ceil (n/2) guardians
- transfer is immediate upon signature validation

[RecoveryManager code coverage report](https://252-166830546-gh.circle-artifacts.com/0/coverage/contracts/modules/RecoveryManager.sol.html)



