### PR TITLE
Fix/wf audit comments

### DIFF
--- a/contracts/wallet/WalletFactory.sol
+++ b/contracts/wallet/WalletFactory.sol
@@ -106,6 +106,7 @@ contract WalletFactory is Owned, Managed {
         onlyManager
         guardianStorageDefined
     {
+        require(_guardian != (address(0)), "WF: guardian cannot be null");
         _createWallet(_owner, _modules, _label, _guardian);
     }
 
@@ -151,6 +152,7 @@ contract WalletFactory is Owned, Managed {
         onlyManager
         guardianStorageDefined
     {
+        require(_guardian != (address(0)), "WF: guardian cannot be null");
         _createCounterfactualWallet(_owner, _modules, _label, _guardian, _salt);
     }
 
@@ -191,6 +193,7 @@ contract WalletFactory is Owned, Managed {
         view
         returns (address _wallet)
     {
+        require(_guardian != (address(0)), "WF: guardian cannot be null");
         _wallet = _getAddressForCounterfactualWallet(_owner, _modules, _guardian, _salt);
     }
 
@@ -237,12 +240,12 @@ contract WalletFactory is Owned, Managed {
 
     /**
      * @dev Helper method to create a wallet for an owner account.
-     * The wallet is initialised with a list of modules, a first guardian, and an ENS..
+     * The wallet is initialised with a list of modules, a first guardian, and an ENS.
      * The wallet is created using the CREATE opcode.
      * @param _owner The account address.
      * @param _modules The list of modules.
      * @param _label ENS label of the new wallet, e.g. franck.
-     * @param _guardian The guardian address.
+     * @param _guardian (Optional) The guardian address.
      */
     function _createWallet(address _owner, address[] memory _modules, string memory _label, address _guardian) internal {
         _validateInputs(_owner, _modules, _label);
@@ -288,7 +291,7 @@ contract WalletFactory is Owned, Managed {
      * @param _owner The account address.
      * @param _modules The list of modules.
      * @param _label ENS label of the new wallet, e.g. franck.
-     * @param _guardian The guardian address.
+     * @param _guardian (Optional) The guardian address.
      */
     function _configureWallet(
         BaseWallet _wallet,
@@ -324,7 +327,7 @@ contract WalletFactory is Owned, Managed {
      * @param _owner The account address.
      * @param _modules The list of modules.
      * @param _salt The salt.
-     * @param _guardian The guardian address.
+     * @param _guardian (Optional) The guardian address.
      * @return the address that the wallet will have when created using CREATE2 and the same input parameters.
      */
     function _getAddressForCounterfactualWallet(

--- a/test/factory.js
+++ b/test/factory.js
@@ -434,7 +434,7 @@ describe("Test Wallet Factory", function () {
             let label = "wallet" + index; 
             let modules = [module1.contractAddress, module2.contractAddress]; 
             // we get the future address
-            let futureAddr = await factory.getAddressForCounterfactualWallet(owner.address, modules, salt); 
+            let futureAddr = await factory.getAddressForCounterfactualWalletWithGuardian(owner.address, modules, guardian.address, salt); 
             // we create the wallet
             let tx = await factory.from(infrastructure).createCounterfactualWalletWithGuardian(owner.address, modules, label, guardian.address, salt);
             let txReceipt = await factory.verboseWaitForTransaction(tx);
@@ -448,7 +448,7 @@ describe("Test Wallet Factory", function () {
             let label = "wallet" + index; 
             let modules = [module1.contractAddress, module2.contractAddress];
             // we get the future address
-            let futureAddr = await factory.getAddressForCounterfactualWallet(owner.address, modules, salt);
+            let futureAddr = await factory.getAddressForCounterfactualWalletWithGuardian(owner.address, modules, guardian.address, salt); 
             // we create the wallet
             let tx = await factory.from(infrastructure).createCounterfactualWalletWithGuardian(owner.address, modules, label, guardian.address, salt);
             let txReceipt = await factory.verboseWaitForTransaction(tx);
@@ -466,7 +466,7 @@ describe("Test Wallet Factory", function () {
             let label = "wallet" + index; 
             let modules = [module1.contractAddress, module2.contractAddress];
             // we get the future address
-            let futureAddr = await factory.getAddressForCounterfactualWallet(owner.address, modules, salt);
+            let futureAddr = await factory.getAddressForCounterfactualWalletWithGuardian(owner.address, modules, guardian.address, salt); 
             // we create the wallet
             let tx = await factory.from(infrastructure).createCounterfactualWalletWithGuardian(owner.address, modules, label, guardian.address, salt);
             let txReceipt = await factory.verboseWaitForTransaction(tx);
@@ -483,7 +483,7 @@ describe("Test Wallet Factory", function () {
             let label = "wallet" + index; 
             let modules = [module1.contractAddress, module2.contractAddress];
             // we get the future address
-            let futureAddr = await factory.getAddressForCounterfactualWallet(owner.address, modules, salt);
+            let futureAddr = await factory.getAddressForCounterfactualWalletWithGuardian(owner.address, modules, guardian.address, salt); 
             // we create the wallet
             let tx = await factory.from(infrastructure).createCounterfactualWalletWithGuardian(owner.address, modules, label, guardian.address, salt);
             let txReceipt = await factory.verboseWaitForTransaction(tx);
@@ -504,7 +504,7 @@ describe("Test Wallet Factory", function () {
             let labelNode = ethers.utils.namehash(label + '.' + subnameWallet + "." + root);
             let modules = [module1.contractAddress, module2.contractAddress];
             // we get the future address
-            let futureAddr = await factory.getAddressForCounterfactualWallet(owner.address, modules, salt);
+            let futureAddr = await factory.getAddressForCounterfactualWalletWithGuardian(owner.address, modules, guardian.address, salt); 
             // we create the wallet
             let tx = await factory.from(infrastructure).createCounterfactualWalletWithGuardian(owner.address, modules, label, guardian.address, salt);
             let txReceipt = await factory.verboseWaitForTransaction(tx);
@@ -523,7 +523,7 @@ describe("Test Wallet Factory", function () {
             let label = "wallet" + index; 
             let modules = [module1.contractAddress, module2.contractAddress];
             // we get the future address
-            let futureAddr = await factory.getAddressForCounterfactualWallet(owner.address, modules, salt);
+            let futureAddr = await factory.getAddressForCounterfactualWalletWithGuardian(owner.address, modules, guardian.address, salt); 
             // we create the first wallet
             let tx = await factory.from(infrastructure).createCounterfactualWalletWithGuardian(owner.address, modules, label, guardian.address, salt);
             let txReceipt = await factory.verboseWaitForTransaction(tx);

--- a/test/factory.js
+++ b/test/factory.js
@@ -13,6 +13,7 @@ const TestManager = require("../utils/test-manager");
 const { randomBytes, bigNumberify } = require('ethers').utils;
 const utilities = require('../utils/utilities.js');
 const ZERO_BYTES32 = ethers.constants.HashZero;
+const ZERO_ADDRESS = ethers.constants.AddressZero;
 const NO_ENS = "";
 
 describe("Test Wallet Factory", function () {
@@ -283,6 +284,13 @@ describe("Test Wallet Factory", function () {
             let modules = [module1.contractAddress, module2.contractAddress];
             await assert.revertWith(factoryWithoutGuardianStorage.from(infrastructure).createWalletWithGuardian(owner.address, modules, label, guardian.address), "GuardianStorage address not defined");
         });
+
+        it("should fail to create when the guardian is empty", async () => {
+            // we create the wallet
+            let label = "wallet" + index; 
+            let modules = [module1.contractAddress];
+            await assert.revertWith(factory.from(infrastructure).createWalletWithGuardian(owner.address, modules, label, ZERO_ADDRESS), "WF: guardian cannot be null");
+        });
     });
 
     describe("Create wallets with CREATE2", () => { 
@@ -552,6 +560,20 @@ describe("Test Wallet Factory", function () {
             let label = "wallet" + index; 
             let modules = [module1.contractAddress, module2.contractAddress];
             await assert.revertWith(factoryWithoutGuardianStorage.from(infrastructure).createCounterfactualWalletWithGuardian(owner.address, modules, label, guardian.address, salt), "GuardianStorage address not defined");
+        });
+
+        it("should fail to get an address when the guardian is empty", async () => {
+            let salt = bigNumberify(randomBytes(32)).toHexString ();
+            let label = "wallet" + index; 
+            let modules = [module1.contractAddress, module2.contractAddress];
+            await assert.revertWith(factory.from(infrastructure).getAddressForCounterfactualWalletWithGuardian(owner.address, modules, ZERO_ADDRESS, salt), "WF: guardian cannot be null");
+        });
+
+        it("should fail to create when the guardian is empty", async () => {
+            let salt = bigNumberify(randomBytes(32)).toHexString ();
+            let label = "wallet" + index; 
+            let modules = [module1.contractAddress, module2.contractAddress];
+            await assert.revertWith(factory.from(infrastructure).createCounterfactualWalletWithGuardian(owner.address, modules, label, ZERO_ADDRESS, salt), "WF: guardian cannot be null");
         });
     });
 });

--- a/test/factory.js
+++ b/test/factory.js
@@ -11,7 +11,7 @@ const GuardianStorage = require("../build/GuardianStorage");
 
 const TestManager = require("../utils/test-manager");
 const { randomBytes, bigNumberify } = require('ethers').utils;
-const utils = require('../utils/utilities.js');
+const utilities = require('../utils/utilities.js');
 const ZERO_BYTES32 = ethers.constants.HashZero;
 const NO_ENS = "";
 
@@ -96,7 +96,7 @@ describe("Test Wallet Factory", function () {
 
     describe("Configure the factory", () => {
         it("should allow owner to change the module registry", async () => {
-            const randomAddress = utils.getRandomAddress();
+            const randomAddress = utilities.getRandomAddress();
             await factory.changeModuleRegistry(randomAddress);
             const updatedModuleRegistry = await factory.moduleRegistry();
             assert.equal(updatedModuleRegistry, randomAddress);
@@ -107,12 +107,12 @@ describe("Test Wallet Factory", function () {
         });
 
         it("should not allow non-owner to change the module registry", async () => {
-            const randomAddress = utils.getRandomAddress();
+            const randomAddress = utilities.getRandomAddress();
             await assert.revertWith(factory.from(other).changeModuleRegistry(randomAddress), "Must be owner");
         });
 
         it("should allow owner to change the ens manager", async () => {
-            const randomAddress = utils.getRandomAddress();
+            const randomAddress = utilities.getRandomAddress();
             await factory.changeENSManager(randomAddress);
             const updatedEnsManager = await factory.ensManager();
             assert.equal(updatedEnsManager, randomAddress);
@@ -123,7 +123,7 @@ describe("Test Wallet Factory", function () {
         });
 
         it("should not allow non-owner to change the ens manager", async () => {
-            const randomAddress = utils.getRandomAddress();
+            const randomAddress = utilities.getRandomAddress();
             await assert.revertWith(factory.from(other).changeENSManager(randomAddress), "Must be owner");
         });
 
@@ -209,7 +209,7 @@ describe("Test Wallet Factory", function () {
 
         it("should fail to create with unregistered module", async () => {
             let label = "wallet" + index;
-            const randomAddress = utils.getRandomAddress();
+            const randomAddress = utilities.getRandomAddress();
             let modules = [randomAddress];
             await assert.revertWith(factory.from(infrastructure).createWallet(owner.address, modules, label), "WF: one or more modules are not registered");     
         });
@@ -402,7 +402,7 @@ describe("Test Wallet Factory", function () {
             let salt = bigNumberify(randomBytes(32)).toHexString (); 
             let label = "wallet" + index; 
             let modules = [module1.contractAddress, module2.contractAddress]; 
-            let amount = ethers.utils.bigNumberify('10000000000000');
+            let amount = bigNumberify('10000000000000');
             // we get the future address
             let futureAddr = await factory.getAddressForCounterfactualWallet(owner.address, modules, salt); 
             // We send ETH to the address

--- a/utils/utilities.js
+++ b/utils/utilities.js
@@ -1,5 +1,6 @@
 const ethers = require('ethers');
 const readline = require('readline');
+const ethereumUtil = require('ethereumjs-util');
 
 module.exports = {
 
@@ -92,5 +93,10 @@ module.exports = {
             return prevValue + currentValue.slice(2);
         }, "0x");
         return ethers.utils.keccak256(concat).slice(0, 10);
+    },
+    getRandomAddress() {
+        const addressBuffer = ethereumUtil.generateAddress(Math.floor(Math.random() * (100 - 0)));
+        const addressHex = ethereumUtil.bufferToHex(addressBuffer);
+        return ethereumUtil.toChecksumAddress(addressHex);
     }
 }


### PR DESCRIPTION
Addressing the suggestions following the audit of `ArgentENSManager.sol` and `WalletFactory.sol`:
- added the guardian to the salt when creating a wallet with CREATE2 to create a deterministic relationship between wallet address and management rights
- extracted the creation logic of `createWallet` and `createCounterfactualWallet` to an internal method to remove duplicated code.