### PR TITLE
Fix deploy scripts in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bin
 .DS_Store
 .node-xmlhttprequest-sync-*
 .vscode
+.outputParameter
 
 .env
 *.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,7 +26,11 @@ npx etherlime compile --runs 999
 for IDX in "$@"
 do
     FILE=`ls ./deployment/${IDX}_*.js`
+    if [ ! -z "${CI:-}" ]; then
+    npx etherlime deploy --file $FILE --network $NETWORK --compile false
+else
     AWS_PROFILE=argent-$PROFILE AWS_SDK_LOAD_CONFIG=true npx etherlime deploy --file $FILE --network $NETWORK --compile false
+fi
     if [ $? -ne 0 ]; then
         exit 1 # exit with failure status
     fi


### PR DESCRIPTION
Since Circle has no AWS configuration setup (neither should it have it) we alter the command here for CI to get that running again.
Note that deployment script results still need to be checked manually as even [failing scripts report back green build](https://circleci.com/gh/argentlabs/argent-contracts/218). 