### PR TITLE
More flexible approve and call

### DIFF
--- a/contracts/modules/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer.sol
@@ -79,7 +79,7 @@ contract ApprovedTransfer is BaseModule, RelayerModule, BaseTransfer {
 
     /**
     * @dev lets the owner do an ERC20 approve followed by a call to a contract.
-    * The address to approve may be different then the contract to call.
+    * The address to approve may be different than the contract to call.
     * We assume that the contract does not require ETH.
     * @param _wallet The target wallet.
     * @param _token The token to approve.

--- a/contracts/modules/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer.sol
@@ -79,18 +79,21 @@ contract ApprovedTransfer is BaseModule, RelayerModule, BaseTransfer {
 
     /**
     * @dev lets the owner do an ERC20 approve followed by a call to a contract.
-    * We assume that the contract will pull the tokens and does not require ETH.
+    * The address to approve may be different then the contract to call.
+    * We assume that the contract does not require ETH.
     * @param _wallet The target wallet.
     * @param _token The token to approve.
-    * @param _contract The address of the contract.
+    * @param _spender The address to approve.
     * @param _amount The amount of ERC20 tokens to approve.
+    * @param _contract The contract to call.
     * @param _data The encoded method data
     */
     function approveTokenAndCallContract(
         BaseWallet _wallet,
         address _token,
-        address _contract,
+        address _spender,
         uint256 _amount,
+        address _contract,
         bytes calldata _data
     )
         external
@@ -98,7 +101,7 @@ contract ApprovedTransfer is BaseModule, RelayerModule, BaseTransfer {
         onlyWhenUnlocked(_wallet)
     {
         require(!_wallet.authorised(_contract) && _contract != address(_wallet), "AT: Forbidden contract");
-        doApproveToken(_wallet, _token, _contract, _amount);
+        doApproveToken(_wallet, _token, _spender, _amount);
         doCallContract(_wallet, _contract, 0, _data);
     }
 

--- a/lib/test/TestContract.sol
+++ b/lib/test/TestContract.sol
@@ -1,5 +1,5 @@
 pragma solidity ^0.5.4;
-
+import "./TokenConsumer.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 
 /**
@@ -35,12 +35,5 @@ contract TestContract {
             state = _state;
             emit StateSet(_state, _amount);
         }
-    }
-}
-
-contract TokenConsumer {
-
-    function consume(address _erc20, address _from, address _to, uint256 _amount) external returns (bool) {
-        return ERC20(_erc20).transferFrom(_from, _to, _amount);
     }
 }

--- a/lib/test/TestContract.sol
+++ b/lib/test/TestContract.sol
@@ -4,14 +4,19 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 
 /**
  * @title TestContract
- * @dev Represents an arbitrary contract. 
+ * @dev Represents an arbitrary contract.
  * @author Olivier Vdb - <olivier@argent.im>
  */
 contract TestContract {
 
-   	uint256 public state;
+    uint256 public state;
+    TokenConsumer public tokenConsumer;
 
     event StateSet(uint256 indexed _state, uint256 indexed _value);
+
+    constructor() public {
+        tokenConsumer = new TokenConsumer();
+    }
 
     function setState(uint256 _state) public payable {
         state = _state;
@@ -22,5 +27,20 @@ contract TestContract {
         ERC20(_erc20).transferFrom(msg.sender, address(this), _amount);
         state = _state;
         emit StateSet(_state, _amount);
+    }
+
+    function setStateAndPayTokenWithConsumer(uint256 _state, address _erc20, uint256 _amount) public {
+        bool success = tokenConsumer.consume(_erc20, msg.sender, address(this), _amount);
+        if (success) {
+            state = _state;
+            emit StateSet(_state, _amount);
+        }
+    }
+}
+
+contract TokenConsumer {
+
+    function consume(address _erc20, address _from, address _to, uint256 _amount) external returns (bool) {
+        return ERC20(_erc20).transferFrom(_from, _to, _amount);
     }
 }

--- a/lib/test/TokenConsumer.sol
+++ b/lib/test/TokenConsumer.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.4;
+
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
+contract TokenConsumer {
+
+    function consume(address _erc20, address _from, address _to, uint256 _amount) external returns (bool) {
+        return ERC20(_erc20).transferFrom(_from, _to, _amount);
+    }
+}

--- a/scripts/execute.sh
+++ b/scripts/execute.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Usage: ./execute.sh [file] [network] [...params]
+#
+# Examples: ./execute.sh deregister.js staging --module "0xabc" 
+
+set -e # stop the script if any subprocess fails
+
+etherlime compile --runs 999
+
+FILE=$1
+shift
+
+NETWORK=$1
+shift
+
+AWS_PROFILE=argent-$NETWORK AWS_SDK_LOAD_CONFIG=true node $FILE --network $NETWORK "$@"

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -82,7 +82,7 @@ describe("Test Approved Transfer", function () {
         return wallets
     }
 
-    describe("Transfer approved by EOA guardians", () => { return;
+    describe("Transfer approved by EOA guardians", () => {
         it('should transfer ETH with 1 confirmations for 1 guardians', async () => {
             let amountToTransfer = 10000;
             await addGuardians([guardian1])
@@ -157,7 +157,7 @@ describe("Test Approved Transfer", function () {
         });
     });
 
-    describe("Transfer approved by smart-contract guardians", () => { return;
+    describe("Transfer approved by smart-contract guardians", () => {
         it('should transfer ETH with 1 confirmations for 1 guardians', async () => {
             let amountToTransfer = 10000;
             await addGuardians(await createSmartContractGuardians([guardian1]));
@@ -223,7 +223,7 @@ describe("Test Approved Transfer", function () {
         });
     });
 
-    describe("Transfer approved by EOA and smart-contract guardians", () => { return;
+    describe("Transfer approved by EOA and smart-contract guardians", () => {
         it('should transfer ETH with 1 EOA guardian and 2 smart-contract guardians', async () => {
             let amountToTransfer = 10000;
             await addGuardians([guardian1, ...(await createSmartContractGuardians([guardian2, guardian3]))]);
@@ -268,7 +268,7 @@ describe("Test Approved Transfer", function () {
         });
     });
 
-    describe("Contract call approved by EOA and smart-contract guardians", () => { return;
+    describe("Contract call approved by EOA and smart-contract guardians", () => {
 
         let contract, dataToTransfer;
 

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -345,7 +345,7 @@ describe("Test Approved Transfer", function () {
             let before = await erc20.balanceOf(contract.contractAddress);
             // should succeed with 2 confirmations
             dataToTransfer = contract.contract.interface.functions['setStateAndPayToken'].encode([2, erc20.contractAddress, amountToApprove]);
-            let txReceipt = await manager.relay(transferModule, "approveTokenAndCallContract", [wallet.contractAddress, erc20.contractAddress, contract.contractAddress, amountToApprove, contract.contractAddress, dataToTransfer], wallet, [owner, ...sortWalletByAddress([guardian1, guardian2])]);
+            await manager.relay(transferModule, "approveTokenAndCallContract", [wallet.contractAddress, erc20.contractAddress, contract.contractAddress, amountToApprove, contract.contractAddress, dataToTransfer], wallet, [owner, ...sortWalletByAddress([guardian1, guardian2])]);
             let after = await erc20.balanceOf(contract.contractAddress);
             assert.equal(after.sub(before).toNumber(), amountToApprove, 'should have approved and transfered the token amount');
             assert.equal((await contract.state()).toNumber(), 2, 'the state of the external contract should have been changed');
@@ -372,7 +372,7 @@ describe("Test Approved Transfer", function () {
             let before = await erc20.balanceOf(contract.contractAddress); 
             // should succeed with 2 confirmations
             dataToTransfer = contract.contract.interface.functions['setStateAndPayTokenWithConsumer'].encode([2, erc20.contractAddress, amountToApprove]);
-            let txReceipt = await manager.relay(transferModule, "approveTokenAndCallContract", [wallet.contractAddress, erc20.contractAddress, consumer, amountToApprove, contract.contractAddress, dataToTransfer], wallet, [owner, ...sortWalletByAddress([guardian1, guardian2])]);
+            await manager.relay(transferModule, "approveTokenAndCallContract", [wallet.contractAddress, erc20.contractAddress, consumer, amountToApprove, contract.contractAddress, dataToTransfer], wallet, [owner, ...sortWalletByAddress([guardian1, guardian2])]);
             let after = await erc20.balanceOf(contract.contractAddress); 
             assert.equal(after.sub(before).toNumber(), amountToApprove, 'should have approved and transfered the token amount');
             assert.equal((await contract.state()).toNumber(), 2, 'the state of the external contract should have been changed');


### PR DESCRIPTION
Update of the `approveTokenAndCallContract` method of `ApprovedTransfer` module to support the consumer of the approved tokens to be different than the called contract. This is needed to e.g. interact with the 0x protocol where the user needs to approve a specific `AssetProxy` contract before submitting an order to the `Exchange` contract.

Also addition of the `execute.sh` script that was used to execute the `register.js` and `deregister.js` scripts but was kept locally so far.