### PR TITLE
Fix deployment script test

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,10 +27,13 @@ for IDX in "$@"
 do
     FILE=`ls ./deployment/${IDX}_*.js`
     if [ ! -z "${CI:-}" ]; then
-    npx etherlime deploy --file $FILE --network $NETWORK --compile false
-else
-    AWS_PROFILE=argent-$PROFILE AWS_SDK_LOAD_CONFIG=true npx etherlime deploy --file $FILE --network $NETWORK --compile false
-fi
+        echo "Waiting for ganache to launch on port 8545..."
+        while ! nc -z localhost 8545; do sleep 1; done
+        echo "ganache running on port 8545"
+        npx etherlime deploy --file $FILE --network $NETWORK --compile false
+    else
+        AWS_PROFILE=argent-$PROFILE AWS_SDK_LOAD_CONFIG=true npx etherlime deploy --file $FILE --network $NETWORK --compile false
+    fi
     if [ $? -ne 0 ]; then
         exit 1 # exit with failure status
     fi

--- a/utils/multisigexecutor.js
+++ b/utils/multisigexecutor.js
@@ -20,7 +20,7 @@ class MultisigExecutor {
     const nonce = (await this._multisigWrapper.contract.nonce()).toNumber();
 
     // Get the sign Hash
-    const signHash = this.signHash(this._multisigWrapper.contractAddress, contractAddress, 0, data, nonce);
+    const signHash = MultisigExecutor.signHash(this._multisigWrapper.contractAddress, contractAddress, 0, data, nonce);
 
     if (this._autoSign === true) {
       // Get the off chain signature


### PR DESCRIPTION
There were a couple of issues with the deployment scripts which we fix here:

- The JS linting PR required a change to how we call a function which that made `static`
- At some point the ganache client in deployment scripts was not starting as fast as before, meaning the script started running without a proper client to serve its requests. We solve this by waiting for ganache to start before continuing execution.