### PR TITLE
Reverting changes in BaseModule + Not disabling MakerManager yet

### DIFF
--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -35,6 +35,15 @@ contract BaseModule is Module {
     // The address of the Guardian storage
     GuardianStorage internal guardianStorage;
 
+    /**
+     * @dev Throws if the wallet is locked.
+     */
+    modifier onlyWhenUnlocked(BaseWallet _wallet) {
+        // solium-disable-next-line security/no-block-members
+        require(!guardianStorage.isLocked(_wallet), "BM: wallet must be unlocked");
+        _;
+    }
+
     event ModuleCreated(bytes32 name);
     event ModuleInitialised(address wallet);
 
@@ -42,14 +51,6 @@ contract BaseModule is Module {
         registry = _registry;
         guardianStorage = _guardianStorage;
         emit ModuleCreated(_name);
-    }
-
-    /**
-     * @dev Throws if the wallet is locked.
-     */
-    modifier onlyWhenUnlocked(BaseWallet _wallet) {
-        require(!guardianStorage.isLocked(_wallet), "BM: wallet locked");
-        _;
     }
 
     /**

--- a/deployment/7_upgrade_1_6.js
+++ b/deployment/7_upgrade_1_6.js
@@ -17,7 +17,7 @@ const utils = require("../utils/utilities.js");
 
 const TARGET_VERSION = "1.6.0";
 const MODULES_TO_ENABLE = ["ApprovedTransfer", "RecoveryManager", "MakerV2Manager"];
-const MODULES_TO_DISABLE = ["UniswapManager", "MakerManager"];
+const MODULES_TO_DISABLE = ["UniswapManager"];
 
 const BACKWARD_COMPATIBILITY = 3;
 


### PR DESCRIPTION
- Reverting BaseModule as we don't want to change the bytecode of modules that are not being redeployed.
- Not disabling MakerManager