### PR TITLE
Expose getRequiredSignatures method

### DIFF
--- a/contracts/modules/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer.sol
@@ -117,7 +117,7 @@ contract ApprovedTransfer is BaseModule, RelayerModuleV2, BaseTransfer {
         return validateSignatures(_wallet, _signHash, _signatures, OwnerSignature.Required);
     }
 
-    function getRequiredSignatures(BaseWallet _wallet, bytes memory /* _data */) internal view returns (uint256) {
+    function getRequiredSignatures(BaseWallet _wallet, bytes memory /* _data */) public view returns (uint256) {
         // owner  + [n/2] guardians
         return  1 + SafeMath.ceil(guardianStorage.guardianCount(_wallet), 2);
     }

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -192,7 +192,7 @@ contract RecoveryManager is BaseModule, RelayerModuleV2 {
         }
     }
 
-    function getRequiredSignatures(BaseWallet _wallet, bytes memory _data) internal view returns (uint256) {
+    function getRequiredSignatures(BaseWallet _wallet, bytes memory _data) public view returns (uint256) {
         bytes4 methodId = functionPrefix(_data);
         if (methodId == EXECUTE_RECOVERY_PREFIX) {
             return SafeMath.ceil(guardianStorage.guardianCount(_wallet), 2);

--- a/contracts/modules/common/RelayerModuleV2.sol
+++ b/contracts/modules/common/RelayerModuleV2.sol
@@ -61,7 +61,7 @@ contract RelayerModuleV2 is BaseModule {
     * @param _data The data of the relayed transaction.
     * @return The number of required signatures.
     */
-    function getRequiredSignatures(BaseWallet _wallet, bytes memory _data) internal view returns (uint256);
+    function getRequiredSignatures(BaseWallet _wallet, bytes memory _data) public view returns (uint256);
 
     /**
     * @dev Validates the signatures provided with a relayed transaction.

--- a/contracts/test/TestModuleRelayerV2.sol
+++ b/contracts/test/TestModuleRelayerV2.sol
@@ -74,7 +74,7 @@ contract TestModuleRelayerV2 is BaseModule, RelayerModuleV2 {
         return isOwner(_wallet, signer); // "GM: signer must be owner"
     }
 
-    function getRequiredSignatures(BaseWallet /* _wallet */, bytes memory /*_data */) internal view returns (uint256) {
+    function getRequiredSignatures(BaseWallet /* _wallet */, bytes memory /*_data */) public view returns (uint256) {
         return 1;
     }
 

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -143,5 +143,10 @@ describe("RelayerModule", function () {
       const updatedNonceHex = await ethers.utils.hexZeroPad(updatedNonce.toHexString(), 32);
       assert.equal(nonce, updatedNonceHex);
     });
+
+    it("should be able to get required signatures number", async () => {
+      const requiredSignatures = await relayerModuleV2.getRequiredSignatures(wallet.contractAddress, ethers.constants.HashZero);
+      assert.equal(requiredSignatures, 1);
+    });
   });
 });


### PR DESCRIPTION
Make public the `RelayerModuleV2.getRequiredSignatures()` method so it can be used by the backend.