### PR TITLE
Rename back event prop in RecoveryManager

### DIFF
--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -59,10 +59,10 @@ contract RecoveryManager is BaseModule, RelayerModuleV2 {
 
     // *************** Events *************************** //
 
-    event RecoveryExecuted(address indexed _wallet, address indexed _recovery, uint64 executeAfter);
-    event RecoveryFinalized(address indexed _wallet, address indexed _recovery);
-    event RecoveryCanceled(address indexed _wallet, address indexed _recovery);
-    event OwnershipTransfered(address indexed _wallet, address indexed _newOwner);
+    event RecoveryExecuted(address indexed wallet, address indexed _recovery, uint64 executeAfter);
+    event RecoveryFinalized(address indexed wallet, address indexed _recovery);
+    event RecoveryCanceled(address indexed wallet, address indexed _recovery);
+    event OwnershipTransfered(address indexed wallet, address indexed _newOwner);
 
     // *************** Modifiers ************************ //
 


### PR DESCRIPTION
Fix requested by the backend team for 1.6 release to rename back the RecoveryManager event property for `wallet`.