### PR TITLE
Ensure we compile both lib and contracts before deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,8 @@ else
     shift
 fi
 
-npx etherlime compile --runs 999
+npm run compile:lib
+npm run compile
 
 for IDX in "$@"
 do


### PR DESCRIPTION
Currently we need to remember to compile external library contracts before we deploy which is prone to error.