### PR TITLE
Removing duplicate definitions of VatLike

### DIFF
--- a/lib/maker/DssCdpManager.sol
+++ b/lib/maker/DssCdpManager.sol
@@ -1,15 +1,7 @@
 pragma solidity ^0.5.4;
 
 import { LibNote } from "./lib.sol";
-
-contract VatLike {
-    function urns(bytes32, address) public view returns (uint, uint);
-    function hope(address) public;
-    function flux(bytes32, address, address, uint) public;
-    function move(address, address, uint) public;
-    function frob(bytes32, address, address, address, int, int) public;
-    function fork(bytes32, address, address, int, int) public;
-}
+import { VatLike} from "./MakerInterfaces.sol";
 
 contract UrnHandler {
     constructor(address vat) public {

--- a/lib/maker/MakerInterfaces.sol
+++ b/lib/maker/MakerInterfaces.sol
@@ -21,8 +21,12 @@ contract VatLike {
     function ilks(bytes32) public view returns (uint Art, uint rate, uint spot, uint line, uint dust);
     function urns(bytes32, address) public view returns (uint ink, uint art);
     function frob(bytes32, address, address, address, int, int) public;
-    function slip(bytes32,address,int) external;
-    function move(address,address,uint) external;
+    function slip(bytes32,address,int) public;
+    function move(address,address,uint) public;
+    function fold(bytes32,address,int) public;
+    function suck(address,address,uint256) public;
+    function flux(bytes32, address, address, uint) public;
+    function fork(bytes32, address, address, int, int) public;
 }
 
 contract JoinLike {

--- a/lib/maker/MockScdMcdMigration.sol
+++ b/lib/maker/MockScdMcdMigration.sol
@@ -10,8 +10,12 @@ contract MockVat is VatLike {
     function ilks(bytes32) public view returns (uint, uint, uint, uint, uint) { return (0, 0, 0, 0, 0); }
     function urns(bytes32, address) public view returns (uint, uint) { return (0, 0); }
     function frob(bytes32, address, address, address, int, int) public {}
-    function slip(bytes32,address,int) external {}
-    function move(address,address,uint) external {}
+    function slip(bytes32,address,int) public {}
+    function move(address,address,uint) public {}
+    function fold(bytes32,address,int) public {}
+    function suck(address,address,uint256) public {}
+    function flux(bytes32, address, address, uint) public {}
+    function fork(bytes32, address, address, int, int) public {}
 }
 
 contract MockTub is SaiTubLike {

--- a/lib/maker/jug.sol
+++ b/lib/maker/jug.sol
@@ -1,14 +1,7 @@
 pragma solidity ^0.5.4;
 
-import "./lib.sol";
-
-contract VatLike {
-    function ilks(bytes32) external returns (
-        uint256 Art,   // wad
-        uint256 rate   // ray
-    );
-    function fold(bytes32,address,int) external;
-}
+import { LibNote } from "./lib.sol";
+import { VatLike} from "./MakerInterfaces.sol";
 
 contract Jug is LibNote {
     // --- Auth ---
@@ -100,7 +93,7 @@ contract Jug is LibNote {
     // --- Stability Fee Collection ---
     function drip(bytes32 ilk) external note returns (uint rate) {
         require(now >= ilks[ilk].rho, "Jug/invalid-now");
-        (, uint prev) = vat.ilks(ilk);
+        (,uint prev,,,) = vat.ilks(ilk);
         rate = rmul(rpow(add(base, ilks[ilk].duty), now - ilks[ilk].rho, ONE), prev);
         vat.fold(ilk, vow, diff(rate, prev));
         ilks[ilk].rho = now;

--- a/lib/maker/pot.sol
+++ b/lib/maker/pot.sol
@@ -17,7 +17,8 @@
 
 pragma solidity ^0.5.4;
 
-import "./lib.sol";
+import { LibNote } from "./lib.sol";
+import { VatLike} from "./MakerInterfaces.sol";
 
 /*
    "Savings Dai" is obtained when Dai is deposited into
@@ -37,11 +38,6 @@ import "./lib.sol";
    - `drip`: perform rate collection
 
 */
-
-contract VatLike {
-    function move(address,address,uint256) external;
-    function suck(address,address,uint256) external;
-}
 
 contract Pot is LibNote {
     // --- Auth ---


### PR DESCRIPTION
VatLike was being defined by multiple third-party contracts, which may cause issues.