### PR TITLE
SimpleUpgrader ensure a module is registered before upgrading

### DIFF
--- a/contracts/infrastructure/WalletFactory.sol
+++ b/contracts/infrastructure/WalletFactory.sol
@@ -371,7 +371,7 @@ contract WalletFactory is Owned, Managed {
         require(_modules.length > 0, "WF: cannot assign with less than 1 module");
         require(ModuleRegistry(moduleRegistry).isRegisteredModule(_modules), "WF: one or more modules are not registered");
         bytes memory labelBytes = bytes(_label);
-        require(labelBytes.length != 0, "WF: ENS lable must be defined");
+        require(labelBytes.length != 0, "WF: ENS label must be defined");
     }
 
     /**

--- a/contracts/modules/SimpleUpgrader.sol
+++ b/contracts/modules/SimpleUpgrader.sol
@@ -53,6 +53,7 @@ contract SimpleUpgrader is BaseModule {
         uint256 i = 0;
         //add new modules
         for (; i < toEnable.length; i++) {
+            require(registry.isRegisteredModule(toEnable[i]), "SU: module is not registered");
             BaseWallet(_wallet).authoriseModule(toEnable[i], true);
         }
         //remove old modules

--- a/contracts/modules/SimpleUpgrader.sol
+++ b/contracts/modules/SimpleUpgrader.sol
@@ -50,10 +50,11 @@ contract SimpleUpgrader is BaseModule {
      * @param _wallet The target wallet.
      */
     function init(BaseWallet _wallet) public onlyWallet(_wallet) {
+        require(registry.isRegisteredModule(toEnable), "SU: Not all modules are registered");
+
         uint256 i = 0;
         //add new modules
         for (; i < toEnable.length; i++) {
-            require(registry.isRegisteredModule(toEnable[i]), "SU: module is not registered");
             BaseWallet(_wallet).authoriseModule(toEnable[i], true);
         }
         //remove old modules

--- a/test/factory.js
+++ b/test/factory.js
@@ -196,7 +196,7 @@ describe("Wallet Factory", function () {
 
     it("should fail to create when there is no ENS", async () => {
       const modules = [module1.contractAddress, module2.contractAddress];
-      await assert.revertWith(factory.from(infrastructure).createWallet(owner.address, modules, NO_ENS), "WF: ENS lable must be defined");
+      await assert.revertWith(factory.from(infrastructure).createWallet(owner.address, modules, NO_ENS), "WF: ENS label must be defined");
     });
 
     it("should fail to create with an existing ENS", async () => {
@@ -231,7 +231,7 @@ describe("Wallet Factory", function () {
     it("should fail to create with empty label", async () => {
       const label = "";
       const modules = [module1.contractAddress];
-      await assert.revertWith(factory.from(infrastructure).createWallet(owner.address, modules, label), "WF: ENS lable must be defined");
+      await assert.revertWith(factory.from(infrastructure).createWallet(owner.address, modules, label), "WF: ENS label must be defined");
     });
   });
 
@@ -418,7 +418,7 @@ describe("Wallet Factory", function () {
       const label = "";
       const modules = [module1.contractAddress, module2.contractAddress];
       await assert.revertWith(factory.from(deployer).createCounterfactualWallet(owner.address, modules, label, salt),
-        "WF: ENS lable must be defined");
+        "WF: ENS label must be defined");
     });
 
     it("should emit and event when the balance is non zero at creation", async () => {

--- a/test/simpleUpgrader.js
+++ b/test/simpleUpgrader.js
@@ -94,7 +94,7 @@ describe("SimpleUpgrader", function () {
       await registry.registerModule(upgrader.contractAddress, formatBytes32String("V1toV2"));
 
       // check we can't upgrade from V1 to V2
-      await assert.revertWith(moduleV1.from(owner).addModule(wallet.contractAddress, upgrader.contractAddress), "SU: module is not registered");
+      await assert.revertWith(moduleV1.from(owner).addModule(wallet.contractAddress, upgrader.contractAddress), "SU: Not all modules are registered");
       // register module V2
       await registry.registerModule(moduleV2.contractAddress, formatBytes32String("V2"));
       // now we can upgrade


### PR DESCRIPTION
Before we could perform an upgrade via SimpleUpgrader to a module that is not registered in the ModuleRegistry. Here we add a check to ensure that can't happen.

We also fix a small typo in a revert message in `WalletFactory` here.