### PR TITLE
Enable recovery of non compliant tokens

### DIFF
--- a/contracts-test/NonCompliantERC20.sol
+++ b/contracts-test/NonCompliantERC20.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.6.10;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+/**
+ * NonCompliantERC20 test contract.
+ * Ref: https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
+ * https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
+ * This contract is modelled as a basic version of the OMG token 0xd26114cd6EE289AccF82350c8d8487fedB8A0C07
+ * which is probably the more popular token example of the non-ERC20 compliant token problem described above.
+ */
+
+contract BasicToken {
+    using SafeMath for uint;
+
+    mapping(address => uint) balances;
+
+    event Approval(address indexed owner, address indexed spender, uint value);
+    event Transfer(address indexed from, address indexed to, uint value);
+
+
+    /**
+    * @dev Fix for the ERC20 short address attack.
+    */
+    modifier onlyPayloadSize(uint size) {
+        if (msg.data.length < size + 4) {
+            revert("throw");
+        }
+        _;
+    }
+
+    /**
+    * @dev transfer token for a specified address
+    * @param _to The address to transfer to.
+    * @param _value The amount to be transferred.
+    */
+    function transfer(address _to, uint _value) public onlyPayloadSize(2 * 32) {
+        balances[msg.sender] = balances[msg.sender].sub(_value);
+        balances[_to] = balances[_to].add(_value);
+        emit Transfer(msg.sender, _to, _value);
+    }
+
+    /**
+    * @dev Gets the balance of the specified address.
+    * @param _owner The address to query the the balance of.
+    * @return balance An uint representing the amount owned by the passed address.
+    */
+    function balanceOf(address _owner) public view returns (uint balance) {
+        return balances[_owner];
+    }
+}
+
+contract StandardToken is BasicToken {
+
+    mapping (address => mapping (address => uint)) allowed;
+
+    /**
+    * @dev Transfer tokens from one address to another
+    * @param _from address The address which you want to send tokens from
+    * @param _to address The address which you want to transfer to
+    * @param _value uint the amout of tokens to be transfered
+    */
+    function transferFrom(address _from, address _to, uint _value) public onlyPayloadSize(3 * 32) {
+        uint _allowance = allowed[_from][msg.sender];
+
+        // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
+        // if (_value > _allowance) throw;
+
+        balances[_to] = balances[_to].add(_value);
+        balances[_from] = balances[_from].sub(_value);
+        allowed[_from][msg.sender] = _allowance.sub(_value);
+        emit Transfer(_from, _to, _value);
+    }
+
+    /**
+    * @dev Aprove the passed address to spend the specified amount of tokens on beahlf of msg.sender.
+    * @param _spender The address which will spend the funds.
+    * @param _value The amount of tokens to be spent.
+    */
+    function approve(address _spender, uint _value) public {
+        // To change the approve amount you first have to reduce the addresses`
+        //  allowance to zero by calling `approve(_spender, 0)` if it is not
+        //  already 0 to mitigate the race condition described here:
+        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+        if ((_value != 0) && (allowed[msg.sender][_spender] != 0)) {
+            revert("throw");
+        }
+
+        allowed[msg.sender][_spender] = _value;
+        emit Approval(msg.sender, _spender, _value);
+    }
+
+    /**
+    * @dev Function to check the amount of tokens than an owner allowed to a spender.
+    * @param _owner address The address which owns the funds.
+    * @param _spender address The address which will spend the funds.
+    * @return remaining A uint specifing the amount of tokens still avaible for the spender.
+    */
+    function allowance(address _owner, address _spender) public view returns (uint remaining) {
+        return allowed[_owner][_spender];
+    }
+
+}
+
+contract MintableToken is StandardToken {
+    event Mint(address indexed to, uint value);
+    event MintFinished();
+
+    bool public mintingFinished = false;
+    uint public totalSupply = 0;
+
+    modifier canMint() {
+        if (mintingFinished) {
+            revert("throw");
+        }
+        _;
+    }
+
+    /**
+    * @dev Function to mint tokens
+    * @param _to The address that will recieve the minted tokens.
+    * @param _amount The amount of tokens to mint.
+    * @return A boolean that indicates if the operation was successful.
+    */
+    function mint(address _to, uint _amount) public canMint returns (bool) {
+        totalSupply = totalSupply.add(_amount);
+        balances[_to] = balances[_to].add(_amount);
+        emit Mint(_to, _amount);
+        return true;
+    }
+
+    /**
+    * @dev Function to stop minting new tokens.
+    * @return True if the operation was successful.
+    */
+    function finishMinting() public returns (bool) {
+        mintingFinished = true;
+        emit MintFinished();
+        return true;
+    }
+}
+
+contract NonCompliantERC20 is MintableToken {
+
+}

--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -87,8 +87,7 @@ contract BaseModule is IModule {
     */
     function recoverToken(address _token) external override {
         uint total = ERC20(_token).balanceOf(address(this));
-        bool success = ERC20(_token).transfer(address(registry), total);
-        require(success, "BM: recover token transfer failed");
+        _token.call(abi.encodeWithSelector(ERC20(_token).transfer.selector, address(registry), total));
     }
 
     /**

--- a/scripts/provision_lib_artefacts.sh
+++ b/scripts/provision_lib_artefacts.sh
@@ -28,6 +28,7 @@ cp build/CryptoKittyTest.json .coverage_artifacts/CryptoKittyTest.json
 cp build/TestRegistry.json .coverage_artifacts/TestRegistry.json
 cp build/GemJoin.json .coverage_artifacts/GemJoin.json
 cp build/NewTestModule.json .coverage_artifacts/NewTestModule.json
+cp build/NonCompliantERC20.json .coverage_artifacts/NonCompliantERC20.json
 cp build/NonCompliantGuardian.json .coverage_artifacts/NonCompliantGuardian.json
 cp build/FaucetUser.json .coverage_artifacts/FaucetUser.json
 cp build/TestCdpManager.json .coverage_artifacts/TestCdpManager.json

--- a/test/baseModule.js
+++ b/test/baseModule.js
@@ -52,15 +52,10 @@ describe("BaseModule", function () {
       assert.equal(moduleregistryBalance, 10000000);
     });
 
-    it.skip("should be able to recover non-ERC20 compliant tokens sent to the module", async () => {
+    it("should be able to recover non-ERC20 compliant tokens sent to the module", async () => {
       const nonCompliantToken = await deployer.deploy(NonCompliantERC20, {});
-      await nonCompliantToken.mint(owner.address, 10000000);
-
+      await nonCompliantToken.mint(baseModule.contractAddress, 10000000);
       let balance = await nonCompliantToken.balanceOf(baseModule.contractAddress);
-      assert.equal(balance, 0);
-
-      await nonCompliantToken.from(owner).transfer(baseModule.contractAddress, 10000000);
-      balance = await nonCompliantToken.balanceOf(baseModule.contractAddress);
       assert.equal(balance, 10000000);
 
       await baseModule.recoverToken(nonCompliantToken.contractAddress);

--- a/test/baseModule.js
+++ b/test/baseModule.js
@@ -1,0 +1,53 @@
+/* global accounts */
+const ethers = require("ethers");
+
+const Registry = require("../build/ModuleRegistry");
+const GuardianStorage = require("../build/GuardianStorage");
+const BaseModule = require("../build/BaseModule");
+const ERC20 = require("../build/TestERC20");
+
+const TestManager = require("../utils/test-manager");
+
+describe("BaseModule", function () {
+  this.timeout(10000);
+
+  const manager = new TestManager();
+  const { deployer } = manager;
+
+  const owner = accounts[1].signer;
+
+  let registry;
+  let guardianStorage;
+  let token;
+  let baseModule;
+
+  before(async () => {
+  });
+
+  beforeEach(async () => {
+    registry = await deployer.deploy(Registry);
+    guardianStorage = await deployer.deploy(GuardianStorage);
+    token = await deployer.deploy(ERC20, {}, [owner.address], 10, 18);
+    const name = ethers.utils.formatBytes32String("BaseModule");
+    baseModule = await deployer.deploy(BaseModule, {}, registry.contractAddress, guardianStorage.contractAddress, name);
+  });
+
+  describe("Recover token", async () => {
+    it("should be able to recover ERC20 tokens sent to the module", async () => {
+      let balance = await token.balanceOf(baseModule.contractAddress);
+      assert.equal(balance, 0);
+
+      await token.from(owner).transfer(baseModule.contractAddress, 10000000);
+      balance = await token.balanceOf(baseModule.contractAddress);
+      assert.equal(balance, 10000000);
+
+      await baseModule.recoverToken(token.contractAddress);
+
+      balance = await token.balanceOf(baseModule.contractAddress);
+      assert.equal(balance, 0);
+
+      const moduleregistryBalance = await token.balanceOf(registry.contractAddress);
+      assert.equal(moduleregistryBalance, 10000000);
+    });
+  });
+});

--- a/test/baseModule.js
+++ b/test/baseModule.js
@@ -5,6 +5,7 @@ const Registry = require("../build/ModuleRegistry");
 const GuardianStorage = require("../build/GuardianStorage");
 const BaseModule = require("../build/BaseModule");
 const ERC20 = require("../build/TestERC20");
+const NonCompliantERC20 = require("../build/NonCompliantERC20");
 
 const TestManager = require("../utils/test-manager");
 
@@ -28,11 +29,12 @@ describe("BaseModule", function () {
     registry = await deployer.deploy(Registry);
     guardianStorage = await deployer.deploy(GuardianStorage);
     token = await deployer.deploy(ERC20, {}, [owner.address], 10, 18);
+
     const name = ethers.utils.formatBytes32String("BaseModule");
     baseModule = await deployer.deploy(BaseModule, {}, registry.contractAddress, guardianStorage.contractAddress, name);
   });
 
-  describe("Recover token", async () => {
+  describe("Recover tokens", async () => {
     it("should be able to recover ERC20 tokens sent to the module", async () => {
       let balance = await token.balanceOf(baseModule.contractAddress);
       assert.equal(balance, 0);
@@ -47,6 +49,26 @@ describe("BaseModule", function () {
       assert.equal(balance, 0);
 
       const moduleregistryBalance = await token.balanceOf(registry.contractAddress);
+      assert.equal(moduleregistryBalance, 10000000);
+    });
+
+    it.skip("should be able to recover non-ERC20 compliant tokens sent to the module", async () => {
+      const nonCompliantToken = await deployer.deploy(NonCompliantERC20, {});
+      await nonCompliantToken.mint(owner.address, 10000000);
+
+      let balance = await nonCompliantToken.balanceOf(baseModule.contractAddress);
+      assert.equal(balance, 0);
+
+      await nonCompliantToken.from(owner).transfer(baseModule.contractAddress, 10000000);
+      balance = await nonCompliantToken.balanceOf(baseModule.contractAddress);
+      assert.equal(balance, 10000000);
+
+      await baseModule.recoverToken(nonCompliantToken.contractAddress);
+
+      balance = await nonCompliantToken.balanceOf(baseModule.contractAddress);
+      assert.equal(balance, 0);
+
+      const moduleregistryBalance = await nonCompliantToken.balanceOf(registry.contractAddress);
       assert.equal(moduleregistryBalance, 10000000);
     });
   });


### PR DESCRIPTION
Enables recovery of non compliant tokens in the BaseModule. The same logic is needed for the ModuleManager however that is not part of 2.0 release so leaving those changes out on the backlog.  

The test non compliant token was modelled as a basic version of the OMG token 0xd26114cd6EE289AccF82350c8d8487fedB8A0C07