### PR TITLE
Move slither analysis to nightly job in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,4 +86,13 @@ workflows:
   commit:
     jobs:
       - unit-test
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 1 * * *" # 1am UTC
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
       - security-test


### PR DESCRIPTION
We've been having some differentiating results between local runs and CI which has been slowing down the review process. Here we move the security analysis to a nightly job to be reviewed at a higher level when the release is reviewed and prepared overall.