### PR TITLE
Improve the required signatures logic in relayer

### DIFF
--- a/contracts-test/BadModuleRelayer.sol
+++ b/contracts-test/BadModuleRelayer.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.6.10;
+import "../contracts/modules/common/BaseModule.sol";
+import "../contracts/modules/common/RelayerModule.sol";
+
+contract BadModuleRelayer is BaseModule, RelayerModule {
+
+    bytes32 constant NAME = "BadModuleRelayer";
+
+    constructor(IModuleRegistry _registry, IGuardianStorage _guardianStorage)
+    BaseModule(_registry, _guardianStorage, NAME) public
+    {
+    }
+
+    uint uintVal;
+    function setIntOwnerOnly(address _wallet, uint _val) external {
+        uintVal = _val;
+    }
+
+    // *************** Implementation of RelayerModule methods ********************* //
+
+    // Overrides to use the incremental nonce and save some gas
+    function checkAndUpdateUniqueness(address _wallet, uint256 _nonce, bytes32 /* _signHash */) internal override returns (bool) {
+        return checkAndUpdateNonce(_wallet, _nonce);
+    }
+
+    function getRequiredSignatures(address /* _wallet */, bytes memory /*_data */) public view override returns (uint256, OwnerSignature) {
+        return (0, OwnerSignature.Required);
+    }
+}

--- a/contracts/modules/GuardianManager.sol
+++ b/contracts/modules/GuardianManager.sol
@@ -215,7 +215,7 @@ contract GuardianManager is RelayerModule {
         bytes4 methodId = functionPrefix(_data);
 
         if (methodId == CONFIRM_ADDITION_PREFIX || methodId == CONFIRM_REVOKATION_PREFIX) {
-            return (0, OwnerSignature.Required);
+            return (0, OwnerSignature.Anyone);
         } else {
             return (1, OwnerSignature.Required);
         }

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -182,7 +182,7 @@ contract RecoveryManager is RelayerModule {
             return (numberOfSignaturesRequired, OwnerSignature.Disallowed);
         }
         if (methodId == FINALIZE_RECOVERY_PREFIX) {
-            return (0, OwnerSignature.Required);
+            return (0, OwnerSignature.Anyone);
         }
         if (methodId == CANCEL_RECOVERY_PREFIX) {
             uint numberOfSignaturesRequired = ArgentSafeMath.ceil(recoveryConfigs[_wallet].guardianCount + 1, 2);

--- a/contracts/modules/common/RelayerModule.sol
+++ b/contracts/modules/common/RelayerModule.sol
@@ -91,6 +91,10 @@ abstract contract RelayerModule is BaseModule {
         require(checkAndUpdateUniqueness(_wallet, _nonce, signHash), "RM: Duplicate request");
         require(verifyData(_wallet, _data), "RM: Target of _data != _wallet");
         (uint256 requiredSignatures, OwnerSignature ownerSignatureRequirement) = getRequiredSignatures(_wallet, _data);
+        if (requiredSignatures == 0) {
+            require(ownerSignatureRequirement == OwnerSignature.Anyone, "RM: Wrong number of required signatures");
+        }
+
         require(requiredSignatures * 65 == _signatures.length, "RM: Wrong number of signatures");
         require(requiredSignatures == 0 || validateSignatures(_wallet, signHash, _signatures, ownerSignatureRequirement),
          "RM: Invalid signatures");

--- a/contracts/modules/common/RelayerModule.sol
+++ b/contracts/modules/common/RelayerModule.sol
@@ -37,6 +37,7 @@ abstract contract RelayerModule is BaseModule {
     }
 
     enum OwnerSignature {
+        Anyone,
         Required,
         Optional,
         Disallowed

--- a/contracts/modules/common/RelayerModule.sol
+++ b/contracts/modules/common/RelayerModule.sol
@@ -90,11 +90,9 @@ abstract contract RelayerModule is BaseModule {
         bytes32 signHash = getSignHash(address(this), _wallet, 0, _data, _nonce, _gasPrice, _gasLimit);
         require(checkAndUpdateUniqueness(_wallet, _nonce, signHash), "RM: Duplicate request");
         require(verifyData(_wallet, _data), "RM: Target of _data != _wallet");
-        (uint256 requiredSignatures, OwnerSignature ownerSignatureRequirement) = getRequiredSignatures(_wallet, _data);
-        if (requiredSignatures == 0) {
-            require(ownerSignatureRequirement == OwnerSignature.Anyone, "RM: Wrong number of required signatures");
-        }
 
+        (uint256 requiredSignatures, OwnerSignature ownerSignatureRequirement) = getRequiredSignatures(_wallet, _data);
+        require(requiredSignatures > 0 || ownerSignatureRequirement == OwnerSignature.Anyone, "RM: Wrong number of required signatures");
         require(requiredSignatures * 65 == _signatures.length, "RM: Wrong number of signatures");
         require(requiredSignatures == 0 || validateSignatures(_wallet, signHash, _signatures, ownerSignatureRequirement),
          "RM: Invalid signatures");

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "compile:wallet": "npx etherlime compile --workingDirectory contracts/wallet --runs=999",
     "compile:test": "npx etherlime compile --workingDirectory contracts-test --runs=999",
     "compile": "npm run compile:infrastructure && npm run compile:modules && npm run compile:wallet",
+    "cc": "rm -rf build && rm -rf build-legacy && npm run compile:lib && npm run compile && npm run compile:legacy && npm run compile:test",
     "ganache": "npx etherlime ganache --gasLimit=20700000 -e 10000",
     "kovan-fork": "npx ganache-cli -i 42 -l 20700000 -f https://kovan.infura.io/v3/$(cat .env | sed -En 's/INFURA_KEY=''\"''([^''\"'']+)''\"''/\\1/p')@16988040",
     "kovan-fork-latest": "npx ganache-cli -i 42 -l 20700000 -f https://kovan.infura.io/v3/$(cat .env | sed -En 's/INFURA_KEY=''\"''([^''\"'']+)''\"''/\\1/p')",

--- a/scripts/provision_lib_artefacts.sh
+++ b/scripts/provision_lib_artefacts.sh
@@ -37,4 +37,5 @@ cp build/ERC20Approver.json .coverage_artifacts/ERC20Approver.json
 cp build/TestModuleRelayer.json .coverage_artifacts/TestModuleRelayer.json
 cp build/TestOnlyOwnerModule.json .coverage_artifacts/TestOnlyOwnerModule.json
 cp build/FakeWallet.json .coverage_artifacts/FakeWallet.json
+cp build/BadModuleRelayer.json .coverage_artifacts/BadModuleRelayer.json
 cp build/DS*.json .coverage_artifacts


### PR DESCRIPTION
Add an entry in the `OwnerSignature` enum to make the intention clearer that there are cases where no mandated signatures are required.

Also here squeezed in a new npm command for performing a clean compile.