### PR TITLE
Allow whitelisted tokens to be called in TransferManager

### DIFF
--- a/contracts/modules/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer.sol
@@ -70,7 +70,7 @@ contract ApprovedTransfer is BaseTransfer {
         external
         onlyWalletModule(_wallet)
         onlyWhenUnlocked(_wallet)
-        authorisedContractCall(_wallet, _contract)
+        onlyAuthorisedContractCall(_wallet, _contract)
     {
         doCallContract(_wallet, _contract, _value, _data);
     }
@@ -97,7 +97,7 @@ contract ApprovedTransfer is BaseTransfer {
         external
         onlyWalletModule(_wallet)
         onlyWhenUnlocked(_wallet)
-        authorisedContractCall(_wallet, _contract)
+        onlyAuthorisedContractCall(_wallet, _contract)
     {
         doApproveTokenAndCallContract(_wallet, _token, _spender, _amount, _contract, _data);
     }

--- a/contracts/modules/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer.sol
@@ -70,8 +70,8 @@ contract ApprovedTransfer is BaseTransfer {
         external
         onlyWalletModule(_wallet)
         onlyWhenUnlocked(_wallet)
+        authorisedContractCall(_wallet, _contract)
     {
-        require(!IWallet(_wallet).authorised(_contract) && _contract != _wallet, "AT: Forbidden contract");
         doCallContract(_wallet, _contract, _value, _data);
     }
 
@@ -97,8 +97,8 @@ contract ApprovedTransfer is BaseTransfer {
         external
         onlyWalletModule(_wallet)
         onlyWhenUnlocked(_wallet)
+        authorisedContractCall(_wallet, _contract)
     {
-        require(!IWallet(_wallet).authorised(_contract) && _contract != _wallet, "AT: Forbidden contract");
         doApproveTokenAndCallContract(_wallet, _token, _spender, _amount, _contract, _data);
     }
 

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -248,7 +248,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     {
         if (!isWhitelisted(_wallet, _contract)) {
             // Make sure we don't call a supported ERC20 that's not whitelisted
-            notCoveredByDailyLimit(_wallet, _contract);
+            require(!coveredByDailyLimit(_wallet, _contract), "TM: Forbidden contract");
 
             require(LimitUtils.checkAndUpdateDailySpent(limitStorage, _wallet, _value), "TM: Call contract above daily limit");
         }
@@ -281,7 +281,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     {
         if (!isWhitelisted(_wallet, _spender)) {
             // Make sure we don't call a supported ERC20 that's not whitelisted
-            notCoveredByDailyLimit(_wallet, _contract);
+            require(!coveredByDailyLimit(_wallet, _contract), "TM: Forbidden contract");
             // check if the amount is under the daily limit
             // check the entire amount because the currently approved amount will be restored and should still count towards the daily limit
             uint256 valueInEth = LimitUtils.getEtherValue(tokenPriceStorage, _amount, _token);
@@ -530,10 +530,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     * @param _wallet The target wallet.
     * @param _contract The address of the contract.
      */
-    function notCoveredByDailyLimit(address _wallet, address _contract) internal view {
-        require(
-            tokenPriceStorage.getTokenPrice(_contract) == 0 ||
-            isLimitDisabled(_wallet),
-            "TM: Forbidden contract");
+    function coveredByDailyLimit(address _wallet, address _contract) internal view returns (bool) {
+        return (tokenPriceStorage.getTokenPrice(_contract) > 0 && !isLimitDisabled(_wallet));
     }
 }

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -248,7 +248,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     {
         if (!isWhitelisted(_wallet, _contract)) {
             // Make sure we don't call a supported ERC20 that's not whitelisted
-            isNotManagedTokenOrLimitDisabled(_wallet, _contract);
+            verifyNotKnownTokenOrLimitDisabled(_wallet, _contract);
 
             require(LimitUtils.checkAndUpdateDailySpent(limitStorage, _wallet, _value), "TM: Call contract above daily limit");
         }
@@ -281,7 +281,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     {
         if (!isWhitelisted(_wallet, _spender)) {
             // Make sure we don't call a supported ERC20 that's not whitelisted
-            isNotManagedTokenOrLimitDisabled(_wallet, _contract);
+            verifyNotKnownTokenOrLimitDisabled(_wallet, _contract);
             // check if the amount is under the daily limit
             // check the entire amount because the currently approved amount will be restored and should still count towards the daily limit
             uint256 valueInEth = LimitUtils.getEtherValue(tokenPriceStorage, _amount, _token);
@@ -530,7 +530,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     * @param _wallet The target wallet.
     * @param _contract The address of the contract.
      */
-    function isNotManagedTokenOrLimitDisabled(address _wallet, address _contract) internal view {
+    function verifyNotKnownTokenOrLimitDisabled(address _wallet, address _contract) internal view {
         require(
             tokenPriceStorage.getTokenPrice(_contract) == 0 ||
             isLimitDisabled(_wallet),

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -536,7 +536,9 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
         require(
             _contract != _wallet && // not the wallet itself
             !IWallet(_wallet).authorised(_contract) && // not an authorised module
-            (tokenPriceStorage.getTokenPrice(_contract) == 0 || isLimitDisabled(_wallet)), // not an ERC20 listed in the provider (or limit disabled)
+            (tokenPriceStorage.getTokenPrice(_contract) == 0 ||
+            isLimitDisabled(_wallet) || // not an ERC20 listed in the provider (or limit disabled)
+            isWhitelisted(_wallet, _contract)),
             "TM: Forbidden contract");
     }
 }

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -245,17 +245,14 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
         onlyWalletOwnerOrModule(_wallet)
         onlyWhenUnlocked(_wallet)
     {
-        // Make sure we don't call a module, the wallet itself, or a supported ERC20
+        // Make sure we don't call a module, the wallet itself, or a supported ERC20 that's not whitelisted
         authoriseContractCall(_wallet, _contract);
 
-        if (isWhitelisted(_wallet, _contract)) {
-            // call to whitelist
-            doCallContract(_wallet, _contract, _value, _data);
-        } else {
+        if (!isWhitelisted(_wallet, _contract)) {
             require(LimitUtils.checkAndUpdateDailySpent(limitStorage, _wallet, _value), "TM: Call contract above daily limit");
-            // call under the limit
-            doCallContract(_wallet, _contract, _value, _data);
         }
+
+        doCallContract(_wallet, _contract, _value, _data);
     }
 
     /**
@@ -280,7 +277,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
         onlyWalletOwnerOrModule(_wallet)
         onlyWhenUnlocked(_wallet)
     {
-        // Make sure we don't call a module, the wallet itself, or a supported ERC20
+        // Make sure we don't call a module, the wallet itself, or a supported ERC20 that's not whitelisted
         authoriseContractCall(_wallet, _contract);
 
         if (!isWhitelisted(_wallet, _spender)) {

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -244,7 +244,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
         external
         onlyWalletOwnerOrModule(_wallet)
         onlyWhenUnlocked(_wallet)
-        authorisedContractCall(_wallet, _contract)
+        onlyAuthorisedContractCall(_wallet, _contract)
     {
         if (!isWhitelisted(_wallet, _contract)) {
             // Make sure we don't call a supported ERC20 that's not whitelisted
@@ -277,7 +277,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
         external
         onlyWalletOwnerOrModule(_wallet)
         onlyWhenUnlocked(_wallet)
-        authorisedContractCall(_wallet, _contract)
+        onlyAuthorisedContractCall(_wallet, _contract)
     {
         if (!isWhitelisted(_wallet, _spender)) {
             // Make sure we don't call a supported ERC20 that's not whitelisted

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -246,10 +246,10 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
         onlyWhenUnlocked(_wallet)
         authorisedContractCall(_wallet, _contract)
     {
-        // Make sure we don't call a supported ERC20 that's not whitelisted
-        isAuthorisedToken(_wallet, _contract);
-
         if (!isWhitelisted(_wallet, _contract)) {
+            // Make sure we don't call a supported ERC20 that's not whitelisted
+            isNotManagedTokenOrLimitDisabled(_wallet, _contract);
+
             require(LimitUtils.checkAndUpdateDailySpent(limitStorage, _wallet, _value), "TM: Call contract above daily limit");
         }
 
@@ -279,10 +279,9 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
         onlyWhenUnlocked(_wallet)
         authorisedContractCall(_wallet, _contract)
     {
-        // Make sure we don't call a supported ERC20 that's not whitelisted
-        isAuthorisedToken(_wallet, _contract);
-
         if (!isWhitelisted(_wallet, _spender)) {
+            // Make sure we don't call a supported ERC20 that's not whitelisted
+            isNotManagedTokenOrLimitDisabled(_wallet, _contract);
             // check if the amount is under the daily limit
             // check the entire amount because the currently approved amount will be restored and should still count towards the daily limit
             uint256 valueInEth = LimitUtils.getEtherValue(tokenPriceStorage, _amount, _token);
@@ -531,11 +530,10 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     * @param _wallet The target wallet.
     * @param _contract The address of the contract.
      */
-    function isAuthorisedToken(address _wallet, address _contract, bool isWhitelisted) internal view {
+    function isNotManagedTokenOrLimitDisabled(address _wallet, address _contract) internal view {
         require(
             tokenPriceStorage.getTokenPrice(_contract) == 0 ||
-            isLimitDisabled(_wallet) ||
-            isWhitelisted(_wallet, _contract),
-            "TM: Forbidden token");
+            isLimitDisabled(_wallet),
+            "TM: Forbidden contract");
     }
 }

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -248,7 +248,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     {
         if (!isWhitelisted(_wallet, _contract)) {
             // Make sure we don't call a supported ERC20 that's not whitelisted
-            verifyNotKnownTokenOrLimitDisabled(_wallet, _contract);
+            notCoveredByDailyLimit(_wallet, _contract);
 
             require(LimitUtils.checkAndUpdateDailySpent(limitStorage, _wallet, _value), "TM: Call contract above daily limit");
         }
@@ -281,7 +281,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     {
         if (!isWhitelisted(_wallet, _spender)) {
             // Make sure we don't call a supported ERC20 that's not whitelisted
-            verifyNotKnownTokenOrLimitDisabled(_wallet, _contract);
+            notCoveredByDailyLimit(_wallet, _contract);
             // check if the amount is under the daily limit
             // check the entire amount because the currently approved amount will be restored and should still count towards the daily limit
             uint256 valueInEth = LimitUtils.getEtherValue(tokenPriceStorage, _amount, _token);
@@ -530,7 +530,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     * @param _wallet The target wallet.
     * @param _contract The address of the contract.
      */
-    function verifyNotKnownTokenOrLimitDisabled(address _wallet, address _contract) internal view {
+    function notCoveredByDailyLimit(address _wallet, address _contract) internal view {
         require(
             tokenPriceStorage.getTokenPrice(_contract) == 0 ||
             isLimitDisabled(_wallet),

--- a/contracts/modules/common/BaseTransfer.sol
+++ b/contracts/modules/common/BaseTransfer.sol
@@ -41,9 +41,18 @@ abstract contract BaseTransfer is BaseModule {
         bytes data
     );
     // *************** Internal Functions ********************* //
+    /**
+    * @notice Make sure a contract call is not trying to call a module, the wallet itself, or a supported ERC20.
+    * @param _wallet The target wallet.
+    * @param _contract The address of the contract.
+     */
+    modifier authorisedContractCall(address _wallet, address _contract) {
+        require(_contract != _wallet && !IWallet(_wallet).authorised(_contract), "BT: Forbidden contract");
+        _;
+    }
 
     /**
-    * @dev Helper method to transfer ETH or ERC20 for a wallet.
+    * @notice Helper method to transfer ETH or ERC20 for a wallet.
     * @param _wallet The target wallet.
     * @param _token The ERC20 address.
     * @param _to The recipient.
@@ -61,7 +70,7 @@ abstract contract BaseTransfer is BaseModule {
     }
 
     /**
-    * @dev Helper method to approve spending the ERC20 of a wallet.
+    * @notice Helper method to approve spending the ERC20 of a wallet.
     * @param _wallet The target wallet.
     * @param _token The ERC20 address.
     * @param _spender The spender address.
@@ -74,7 +83,7 @@ abstract contract BaseTransfer is BaseModule {
     }
 
     /**
-    * @dev Helper method to call an external contract.
+    * @notice Helper method to call an external contract.
     * @param _wallet The target wallet.
     * @param _contract The contract address.
     * @param _value The ETH value to transfer.
@@ -86,7 +95,7 @@ abstract contract BaseTransfer is BaseModule {
     }
 
     /**
-    * @dev Helper method to approve a certain amount of token and call an external contract.
+    * @notice Helper method to approve a certain amount of token and call an external contract.
     * The address that spends the _token and the address that is called with _data can be different.
     * @param _wallet The target wallet.
     * @param _token The ERC20 address.

--- a/contracts/modules/common/BaseTransfer.sol
+++ b/contracts/modules/common/BaseTransfer.sol
@@ -46,7 +46,7 @@ abstract contract BaseTransfer is BaseModule {
     * @param _wallet The target wallet.
     * @param _contract The address of the contract.
      */
-    modifier authorisedContractCall(address _wallet, address _contract) {
+    modifier onlyAuthorisedContractCall(address _wallet, address _contract) {
         require(_contract != _wallet && !IWallet(_wallet).authorised(_contract), "BT: Forbidden contract");
         _;
     }

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -248,7 +248,7 @@ describe("Approved Transfer", function () {
           [owner, ...sortWalletByAddress([guardian1, guardian2])]);
         const { success, error } = parseRelayReceipt(txReceipt);
         assert.isFalse(success);
-        assert.equal(error, "AT: Forbidden contract");
+        assert.equal(error, "BT: Forbidden contract");
       });
     });
   });
@@ -272,7 +272,7 @@ describe("Approved Transfer", function () {
             wallet, [owner, ...sortWalletByAddress([guardian1, guardian2])]);
           const { success, error } = parseRelayReceipt(txReceipt);
           assert.isFalse(success);
-          assert.equal(error, "AT: Forbidden contract");
+          assert.equal(error, "BT: Forbidden contract");
         }
 
         it("should revert when target contract is the wallet", async () => {

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -590,11 +590,13 @@ describe("TransferManager", function () {
         assert.ok(await manager.isRevertReason(error, "BM: must be owner or module"));
       }
     });
+
     it("should appprove an ERC20 immediately when the spender is whitelisted ", async () => {
       await transferModule.from(owner).addToWhitelist(wallet.contractAddress, spender.address);
       await manager.increaseTime(3);
       await doDirectApprove({ amount: ETH_LIMIT + 10000 });
     });
+
     it("should fail to appprove an ERC20 when the amount is above the daily limit ", async () => {
       try {
         await doDirectApprove({ amount: ETH_LIMIT + 10000 });
@@ -605,25 +607,22 @@ describe("TransferManager", function () {
   });
 
   describe("Call contract", () => {
-    let contract; let
-      dataToTransfer;
+    let contract;
 
     beforeEach(async () => {
       contract = await deployer.deploy(TestContract);
       assert.equal(await contract.state(), 0, "initial contract state should be 0");
     });
 
-    async function doCallContract({
-      signer = owner, value, state, relayed = false,
-    }) {
-      dataToTransfer = contract.contract.interface.functions.setState.encode([state]);
+    async function doCallContract({ value, state, relayed = false }) {
+      const dataToTransfer = contract.contract.interface.functions.setState.encode([state]);
       const unspentBefore = await transferModule.getDailyUnspent(wallet.contractAddress);
       const params = [wallet.contractAddress, contract.contractAddress, value, dataToTransfer];
       let txReceipt;
       if (relayed) {
-        txReceipt = await manager.relay(transferModule, "callContract", params, wallet, [signer]);
+        txReceipt = await manager.relay(transferModule, "callContract", params, wallet, [owner]);
       } else {
-        const tx = await transferModule.from(signer).callContract(...params);
+        const tx = await transferModule.from(owner).callContract(...params);
         txReceipt = await transferModule.verboseWaitForTransaction(tx);
       }
       assert.isTrue(await utils.hasEvent(txReceipt, transferModule, "CalledContract"), "should have generated CalledContract event");
@@ -635,24 +634,48 @@ describe("TransferManager", function () {
       return txReceipt;
     }
 
-    it("should call a contract and transfer ETH under the limit", async () => {
+    it("should not be able to call the wallet itselt", async () => {
+      const dataToTransfer = contract.contract.interface.functions.setState.encode([4]);
+      const params = [wallet.contractAddress, wallet.contractAddress, 10, dataToTransfer];
+      await assert.revertWith(transferModule.from(owner).callContract(...params), "TM: Forbidden contract");
+    });
+
+    it("should not be able to call a module of the wallet", async () => {
+      const dataToTransfer = contract.contract.interface.functions.setState.encode([4]);
+      const params = [wallet.contractAddress, transferModule.contractAddress, 10, dataToTransfer];
+      await assert.revertWith(transferModule.from(owner).callContract(...params), "TM: Forbidden contract");
+    });
+
+    it("should not be able to call a supported ERC20 token contract", async () => {
+      const dataToTransfer = contract.contract.interface.functions.setState.encode([4]);
+      const params = [wallet.contractAddress, erc20.contractAddress, 10, dataToTransfer];
+      await assert.revertWith(transferModule.from(owner).callContract(...params), "TM: Forbidden contract");
+    });
+
+    it("should be able to call a supported token contract which is whitelisted", async () => {
+      await transferModule.from(owner).addToWhitelist(wallet.contractAddress, erc20.contractAddress);
+      await manager.increaseTime(3);
+      const dataToTransfer = erc20.contract.interface.functions.transfer.encode([infrastructure.address, 4]);
+      const params = [wallet.contractAddress, erc20.contractAddress, 0, dataToTransfer];
+      await transferModule.from(owner).callContract(...params);
+    });
+
+    it("should call a contract and transfer ETH value when under the daily limit", async () => {
       await doCallContract({ value: 10, state: 3 });
     });
-    it("should call a contract and transfer ETH under the limit (relayed) ", async () => {
+
+    it("should call a contract and transfer ETH value when under the daily limit (relayed) ", async () => {
       await doCallContract({ value: 10, state: 3, relayed: true });
     });
 
-    it("should call a contract and transfer ETH above my limit value when the contract is whitelisted ", async () => {
+    it("should call a contract and transfer ETH value above the daily limit when the contract is whitelisted", async () => {
       await transferModule.from(owner).addToWhitelist(wallet.contractAddress, contract.contractAddress);
       await manager.increaseTime(3);
       await doCallContract({ value: ETH_LIMIT + 10000, state: 6 });
     });
+
     it("should fail to call a contract and transfer ETH when the amount is above the daily limit ", async () => {
-      try {
-        await doCallContract({ value: ETH_LIMIT + 10000, state: 6 });
-      } catch (error) {
-        assert.ok(await manager.isRevertReason(error, "above daily limit"));
-      }
+      await assert.revertWith(doCallContract({ value: ETH_LIMIT + 10000, state: 6 }, "above daily limit"));
     });
   });
 

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -637,13 +637,13 @@ describe("TransferManager", function () {
     it("should not be able to call the wallet itselt", async () => {
       const dataToTransfer = contract.contract.interface.functions.setState.encode([4]);
       const params = [wallet.contractAddress, wallet.contractAddress, 10, dataToTransfer];
-      await assert.revertWith(transferModule.from(owner).callContract(...params), "TM: Forbidden contract");
+      await assert.revertWith(transferModule.from(owner).callContract(...params), "BT: Forbidden contract");
     });
 
     it("should not be able to call a module of the wallet", async () => {
       const dataToTransfer = contract.contract.interface.functions.setState.encode([4]);
       const params = [wallet.contractAddress, transferModule.contractAddress, 10, dataToTransfer];
-      await assert.revertWith(transferModule.from(owner).callContract(...params), "TM: Forbidden contract");
+      await assert.revertWith(transferModule.from(owner).callContract(...params), "BT: Forbidden contract");
     });
 
     it("should not be able to call a supported ERC20 token contract", async () => {


### PR DESCRIPTION
Adds a `isWhitelisted()` check inside `TransferManager.authoriseContractCall()`.