### PR TITLE
Adding success checks to CompoundManager

### DIFF
--- a/contracts/modules/CompoundManager.sol
+++ b/contracts/modules/CompoundManager.sol
@@ -393,9 +393,9 @@ contract CompoundManager is OnlyOwnerModule {
     function borrow(address _wallet, address _token, address _cToken, uint256 _amount) internal {
         require(_cToken != address(0), "CM: No market for target token");
         require(_amount > 0, "CM: amount cannot be 0");
-        uint256 initialTokenAmount = _token == ETH_TOKEN_ADDRESS ? _wallet.balance : ERC20(_token).balanceOf(_wallet);
+        uint256 initialTokenAmount = _token == ETH_TOKEN ? _wallet.balance : ERC20(_token).balanceOf(_wallet);
         invokeWallet(_wallet, _cToken, 0, abi.encodeWithSignature("borrow(uint256)", _amount));
-        uint256 finalTokenAmount = _token == ETH_TOKEN_ADDRESS ? _wallet.balance : ERC20(_token).balanceOf(_wallet);
+        uint256 finalTokenAmount = _token == ETH_TOKEN ? _wallet.balance : ERC20(_token).balanceOf(_wallet);
         require(finalTokenAmount > initialTokenAmount, "CM: borrow failed to increase token balance");
     }
 

--- a/contracts/modules/CompoundManager.sol
+++ b/contracts/modules/CompoundManager.sol
@@ -110,7 +110,7 @@ contract CompoundManager is OnlyOwnerModule {
         markets[1] = compoundRegistry.getCToken(_debtToken);
         invokeWallet(_wallet, address(comptroller), 0, abi.encodeWithSignature("enterMarkets(address[])", markets));
         mint(_wallet, markets[0], _collateral, _collateralAmount);
-        borrow(_wallet, markets[1], _debtAmount);
+        borrow(_wallet, _debtToken, markets[1], _debtAmount);
         emit LoanOpened(_wallet, _loanId, _collateral, _collateralAmount, _debtToken, _debtAmount);
     }
 
@@ -207,7 +207,7 @@ contract CompoundManager is OnlyOwnerModule {
     {
         address dToken = compoundRegistry.getCToken(_debtToken);
         enterMarketIfNeeded(_wallet, dToken, address(comptroller));
-        borrow(_wallet, dToken, _debtAmount);
+        borrow(_wallet, _debtToken, dToken, _debtAmount);
         emit DebtAdded(_wallet, _loanId, _debtToken, _debtAmount);
     }
 
@@ -250,7 +250,7 @@ contract CompoundManager is OnlyOwnerModule {
         returns (uint8 _status, uint256 _ethValue)
     {
         (uint error, uint liquidity, uint shortfall) = comptroller.getAccountLiquidity(_wallet);
-        require(error == 0, "Compound: failed to get account liquidity");
+        require(error == 0, "CM: failed to get account liquidity");
         if (liquidity > 0) {
             return (1, liquidity);
         }
@@ -302,7 +302,7 @@ contract CompoundManager is OnlyOwnerModule {
         onlyWalletOwnerOrModule(_wallet)
         onlyWhenUnlocked(_wallet)
     {
-        require(_fraction <= 10000, "CompoundV2: invalid fraction value");
+        require(_fraction <= 10000, "CM: invalid fraction value");
         address cToken = compoundRegistry.getCToken(_token);
         uint shares = ICToken(cToken).balanceOf(_wallet);
         redeem(_wallet, cToken, shares.mul(_fraction).div(10000));
@@ -341,14 +341,16 @@ contract CompoundManager is OnlyOwnerModule {
      * @param _amount The amount of underlying token to add.
      */
     function mint(address _wallet, address _cToken, address _token, uint256 _amount) internal {
-        require(_cToken != address(0), "Compound: No market for target token");
-        require(_amount > 0, "Compound: amount cannot be 0");
+        require(_cToken != address(0), "CM: No market for target token");
+        require(_amount > 0, "CM: amount cannot be 0");
+        uint256 initialCTokenAmount = ERC20(_cToken).balanceOf(_wallet);
         if (_token == ETH_TOKEN) {
             invokeWallet(_wallet, _cToken, _amount, abi.encodeWithSignature("mint()"));
         } else {
             invokeWallet(_wallet, _token, 0, abi.encodeWithSignature("approve(address,uint256)", _cToken, _amount));
             invokeWallet(_wallet, _cToken, 0, abi.encodeWithSignature("mint(uint256)", _amount));
         }
+        require(ERC20(_cToken).balanceOf(_wallet) > initialCTokenAmount, "CM: mint failed");
     }
 
     /**
@@ -358,9 +360,13 @@ contract CompoundManager is OnlyOwnerModule {
      * @param _amount The amount of cToken to redeem.
      */
     function redeem(address _wallet, address _cToken, uint256 _amount) internal {
-        require(_cToken != address(0), "Compound: No market for target token");
-        require(_amount > 0, "Compound: amount cannot be 0");
+        // The following commented `require()` is not necessary as `ICToken(cToken).balanceOf(_wallet)` in `removeInvestment()` would have reverted if `_cToken == address(0)`
+        // It is however left as a comment as a reminder to include it if `removeInvestment()` is changed to use amounts instead of fractions.
+        // require(_cToken != address(0), "CM: No market for target token");
+        require(_amount > 0, "CM: amount cannot be 0");
+        uint256 initialCTokenAmount = ERC20(_cToken).balanceOf(_wallet);
         invokeWallet(_wallet, _cToken, 0, abi.encodeWithSignature("redeem(uint256)", _amount));
+        require(ERC20(_cToken).balanceOf(_wallet) < initialCTokenAmount, "CM: redeem failed");
     }
 
     /**
@@ -370,21 +376,27 @@ contract CompoundManager is OnlyOwnerModule {
      * @param _amount The amount of underlying token to redeem.
      */
     function redeemUnderlying(address _wallet, address _cToken, uint256 _amount) internal {
-        require(_cToken != address(0), "Compound: No market for target token");
-        require(_amount > 0, "Compound: amount cannot be 0");
+        require(_cToken != address(0), "CM: No market for target token");
+        require(_amount > 0, "CM: amount cannot be 0");
+        uint256 initialCTokenAmount = ERC20(_cToken).balanceOf(_wallet);
         invokeWallet(_wallet, _cToken, 0, abi.encodeWithSignature("redeemUnderlying(uint256)", _amount));
+        require(ERC20(_cToken).balanceOf(_wallet) < initialCTokenAmount, "CM: redeemUnderlying failed");
     }
 
     /**
      * @dev Borrows underlying tokens from a cToken contract.
      * @param _wallet The target wallet.
+     * @param _token The token contract.
      * @param _cToken The cToken contract.
      * @param _amount The amount of underlying tokens to borrow.
      */
-    function borrow(address _wallet, address _cToken, uint256 _amount) internal {
-        require(_cToken != address(0), "Compound: No market for target token");
-        require(_amount > 0, "Compound: amount cannot be 0");
+    function borrow(address _wallet, address _token, address _cToken, uint256 _amount) internal {
+        require(_cToken != address(0), "CM: No market for target token");
+        require(_amount > 0, "CM: amount cannot be 0");
+        uint256 initialTokenAmount = _token == ETH_TOKEN_ADDRESS ? _wallet.balance : ERC20(_token).balanceOf(_wallet);
         invokeWallet(_wallet, _cToken, 0, abi.encodeWithSignature("borrow(uint256)", _amount));
+        uint256 finalTokenAmount = _token == ETH_TOKEN_ADDRESS ? _wallet.balance : ERC20(_token).balanceOf(_wallet);
+        require(finalTokenAmount > initialTokenAmount, "CM: borrow failed to increase token balance");
     }
 
     /**
@@ -394,16 +406,23 @@ contract CompoundManager is OnlyOwnerModule {
      * @param _amount The amount of underlying to repay.
      */
     function repayBorrow(address _wallet, address _cToken, uint256 _amount) internal {
-        require(_cToken != address(0), "Compound: No market for target token");
-        require(_amount > 0, "Compound: amount cannot be 0");
+        require(_cToken != address(0), "CM: No market for target token");
+        require(_amount > 0, "CM: amount cannot be 0");
         string memory symbol = ICToken(_cToken).symbol();
+        uint256 initialTokenAmount;
+        uint256 finalTokenAmount;
         if (keccak256(abi.encodePacked(symbol)) == keccak256(abi.encodePacked("cETH"))) {
+            initialTokenAmount = _wallet.balance;
             invokeWallet(_wallet, _cToken, _amount, abi.encodeWithSignature("repayBorrow()"));
+            finalTokenAmount = _wallet.balance;
         } else {
             address token = ICToken(_cToken).underlying();
+            initialTokenAmount = ERC20(token).balanceOf(_wallet);
             invokeWallet(_wallet, token, 0, abi.encodeWithSignature("approve(address,uint256)", _cToken, _amount));
             invokeWallet(_wallet, _cToken, 0, abi.encodeWithSignature("repayBorrow(uint256)", _amount));
+            finalTokenAmount = ERC20(token).balanceOf(_wallet);
         }
+        require(finalTokenAmount < initialTokenAmount, "CM: repayBorrow failed to reduce token balance");
     }
 
     /**

--- a/contracts/modules/CompoundManager.sol
+++ b/contracts/modules/CompoundManager.sol
@@ -396,7 +396,7 @@ contract CompoundManager is OnlyOwnerModule {
         uint256 initialTokenAmount = _token == ETH_TOKEN ? _wallet.balance : ERC20(_token).balanceOf(_wallet);
         invokeWallet(_wallet, _cToken, 0, abi.encodeWithSignature("borrow(uint256)", _amount));
         uint256 finalTokenAmount = _token == ETH_TOKEN ? _wallet.balance : ERC20(_token).balanceOf(_wallet);
-        require(finalTokenAmount > initialTokenAmount, "CM: borrow failed to increase token balance");
+        require(finalTokenAmount > initialTokenAmount, "CM: borrow failed");
     }
 
     /**
@@ -422,7 +422,7 @@ contract CompoundManager is OnlyOwnerModule {
             invokeWallet(_wallet, _cToken, 0, abi.encodeWithSignature("repayBorrow(uint256)", _amount));
             finalTokenAmount = ERC20(token).balanceOf(_wallet);
         }
-        require(finalTokenAmount < initialTokenAmount, "CM: repayBorrow failed to reduce token balance");
+        require(finalTokenAmount < initialTokenAmount, "CM: repayBorrow failed");
     }
 
     /**

--- a/test/compoundManager_invest.js
+++ b/test/compoundManager_invest.js
@@ -303,7 +303,7 @@ describe("Invest Manager with Compound", function () {
 
       it("should fail to remove all of an ERC20 investment when it collateralizes a loan", async () => {
         const collateralAmount = parseEther("1");
-        const debtAmount = parseEther("0.01");
+        const debtAmount = parseEther("0.001");
         await token.from(infrastructure).transfer(wallet.contractAddress, collateralAmount);
         const openLoanParams = [
           wallet.contractAddress,

--- a/test/compoundManager_loan.js
+++ b/test/compoundManager_loan.js
@@ -1,6 +1,6 @@
 /* global accounts, utils */
 const ethers = require("ethers");
-const { parseEther, bigNumberify, formatBytes32String } = require("ethers").utils;
+const { parseEther, bigNumberify } = require("ethers").utils;
 
 const GuardianStorage = require("../build/GuardianStorage");
 const Registry = require("../build/ModuleRegistry");
@@ -51,6 +51,7 @@ describe("Loan Module", function () {
   let cToken2;
   let cEther;
   let comptroller;
+  let oracle;
   let oracleProxy;
   let relayerModule;
 
@@ -60,7 +61,7 @@ describe("Loan Module", function () {
     /* Deploy Compound V2 Architecture */
 
     // deploy price oracle
-    const oracle = await deployer.deploy(PriceOracle);
+    oracle = await deployer.deploy(PriceOracle);
     // deploy comptroller
     const comptrollerProxy = await deployer.deploy(Unitroller);
     const comptrollerImpl = await deployer.deploy(Comptroller);
@@ -266,7 +267,10 @@ describe("Loan Module", function () {
         assert.isTrue(debtBalanceAfter.eq(debtBalanceBefore.add(amount)), `wallet debt should have increase by ${amount} (relayed: ${relayed})`);
       } else {
         assert.isTrue(await utils.hasEvent(txReceipt, loanManager, "DebtRemoved"), "should have generated DebtRemoved event");
-        assert.isTrue(debtBalanceAfter.eq(debtBalanceBefore.sub(amount)), `wallet debt should have decreased by ${amount} (relayed: ${relayed})`);
+        assert.isTrue(
+          debtBalanceAfter.eq(debtBalanceBefore.sub(amount)) || amount.eq(ethers.constants.MaxUint256),
+          `wallet debt should have decreased by ${amount} (relayed: ${relayed})`,
+        );
       }
     }
 
@@ -314,8 +318,15 @@ describe("Loan Module", function () {
         await testOpenLoan({
           collateral: ETH_TOKEN, collateralAmount, debt: token1, debtAmount, relayed: false,
         });
-        const loan = await loanManager.getLoan(wallet.contractAddress, ZERO_BYTES32);
-        assert.isTrue(loan._status === 1 && loan._ethValue > 0, "should have obtained the info of the loan");
+        let loan = await loanManager.getLoan(wallet.contractAddress, ZERO_BYTES32);
+        assert.isTrue(loan._status === 1 && loan._ethValue.gt(0), "should have obtained the liquidity info of the loan");
+
+        await oracle.setUnderlyingPrice(cToken1.contractAddress, WAD.mul(10));
+
+        loan = await loanManager.getLoan(wallet.contractAddress, ZERO_BYTES32);
+        assert.isTrue(loan._status === 2 && loan._ethValue.gt(0), "should have obtained the shortfall info of the loan");
+
+        await oracle.setUnderlyingPrice(cToken1.contractAddress, WAD.div(10));
       });
     });
 
@@ -405,27 +416,27 @@ describe("Loan Module", function () {
       // Reverts
 
       it("should fail to borrow an unknown token", async () => {
-        const params = [wallet.contractAddress, formatBytes32String(""), ethers.constants.AddressZero, parseEther("1")];
+        const params = [wallet.contractAddress, ZERO_BYTES32, ethers.constants.AddressZero, parseEther("1")];
         await assert.revertWith(loanManager.from(owner).addDebt(...params), "CM: No market for target token");
       });
 
       it("should fail to borrow 0 token", async () => {
-        const params = [wallet.contractAddress, formatBytes32String(""), ETH_TOKEN, parseEther("0")];
+        const params = [wallet.contractAddress, ZERO_BYTES32, ETH_TOKEN, parseEther("0")];
         await assert.revertWith(loanManager.from(owner).addDebt(...params), "CM: amount cannot be 0");
       });
 
       it("should fail to borrow token with no collateral", async () => {
-        const params = [wallet.contractAddress, formatBytes32String(""), ETH_TOKEN, parseEther("1")];
+        const params = [wallet.contractAddress, ZERO_BYTES32, ETH_TOKEN, parseEther("1")];
         await assert.revertWith(loanManager.from(owner).addDebt(...params), "CM: borrow failed to increase token balance");
       });
 
       it("should fail to repay an unknown token", async () => {
-        const params = [wallet.contractAddress, formatBytes32String(""), ethers.constants.AddressZero, parseEther("1")];
+        const params = [wallet.contractAddress, ZERO_BYTES32, ethers.constants.AddressZero, parseEther("1")];
         await assert.revertWith(loanManager.from(owner).removeDebt(...params), "CM: No market for target token");
       });
 
       it("should fail to repay 0 token", async () => {
-        const params = [wallet.contractAddress, formatBytes32String(""), ETH_TOKEN, parseEther("0")];
+        const params = [wallet.contractAddress, ZERO_BYTES32, ETH_TOKEN, parseEther("0")];
         await assert.revertWith(loanManager.from(owner).removeDebt(...params), "CM: amount cannot be 0");
       });
 
@@ -528,7 +539,7 @@ describe("Loan Module", function () {
           collateral: ETH_TOKEN, collateralAmount: parseEther("0.5"), debt: token1, debtAmount: parseEther("0.01"), relayed: false,
         });
         await testChangeDebt({
-          loanId, debtToken: token1, amount: parseEther("0.005"), add: true, relayed: false,
+          loanId, debtToken: token1, amount: parseEther("0.005"), add: false, relayed: false,
         });
       });
 
@@ -538,7 +549,17 @@ describe("Loan Module", function () {
           collateral: ETH_TOKEN, collateralAmount: parseEther("0.5"), debt: token1, debtAmount: parseEther("0.01"), relayed: false,
         });
         await testChangeDebt({
-          loanId, debtToken: token1, amount: parseEther("0.005"), add: true, relayed: true,
+          loanId, debtToken: token1, amount: parseEther("0.005"), add: false, relayed: true,
+        });
+      });
+
+      it("should repay the full token1 debt to a ETH/token1 loan (blockchain tx)", async () => {
+        await fundWallet({ ethAmount: parseEther("0.5"), token1Amount: parseEther("0.01") });
+        const loanId = await testOpenLoan({
+          collateral: ETH_TOKEN, collateralAmount: parseEther("0.5"), debt: token1, debtAmount: parseEther("0.01"), relayed: false,
+        });
+        await testChangeDebt({
+          loanId, debtToken: token1, amount: ethers.constants.MaxUint256, add: false, relayed: false,
         });
       });
     });
@@ -591,6 +612,18 @@ describe("Loan Module", function () {
           collateral: token1, collateralAmount: parseEther("0.5"), debt: ETH_TOKEN, debtAmount: parseEther("0.001"), relayed: false,
         });
         await testCloseLoan({ loanId, relayed: true });
+      });
+
+      it("should close a loan collateralized with ETH when there is a pre-existing loan collateralized with token1", async () => {
+        await fundWallet({ ethAmount: parseEther("0.5"), token1Amount: parseEther("0.5") });
+        await testOpenLoan({
+          collateral: token1, collateralAmount: parseEther("0.4"), debt: ETH_TOKEN, debtAmount: parseEther("0.0000001"), relayed: false,
+        });
+        const loanId = await testOpenLoan({
+          collateral: ETH_TOKEN, collateralAmount: parseEther("0.4"), debt: token1, debtAmount: parseEther("0.0000001"), relayed: false,
+        });
+        // should not exit any market
+        await testCloseLoan({ loanId, relayed: false, debtMarkets: 0 });
       });
 
       it("should close an ETH/token1+token2 loan (blockchain tx)", async () => {

--- a/test/compoundManager_loan.js
+++ b/test/compoundManager_loan.js
@@ -322,11 +322,15 @@ describe("Loan Module", function () {
         assert.isTrue(loan._status === 1 && loan._ethValue.gt(0), "should have obtained the liquidity info of the loan");
 
         await oracle.setUnderlyingPrice(cToken1.contractAddress, WAD.mul(10));
-
         loan = await loanManager.getLoan(wallet.contractAddress, ZERO_BYTES32);
         assert.isTrue(loan._status === 2 && loan._ethValue.gt(0), "should have obtained the shortfall info of the loan");
 
+        await oracle.setUnderlyingPrice(cToken1.contractAddress, 0);
+        await assert.revertWith(loanManager.getLoan(wallet.contractAddress, ZERO_BYTES32), "CM: failed to get account liquidity");
+
         await oracle.setUnderlyingPrice(cToken1.contractAddress, WAD.div(10));
+        loan = await loanManager.getLoan(ethers.constants.AddressZero, ZERO_BYTES32);
+        assert.isTrue(loan._status === 0 && loan._ethValue.eq(0), "should have obtained (0,0) for the non-existing loan info");
       });
     });
 


### PR DESCRIPTION
CToken methods such as `mint(uint256)` do not revert when failing but return a non-zero error code instead. 
This PR adds checks to ensure that the expected token balance changes have occurred after a Compound method is executed.