### PR TITLE
Ensure sufficient token balance before executing approve and call

### DIFF
--- a/contracts/modules/common/BaseTransfer.sol
+++ b/contracts/modules/common/BaseTransfer.sol
@@ -114,6 +114,10 @@ abstract contract BaseTransfer is BaseModule {
     )
         internal
     {
+        // Ensure there is sufficient balance of token before we approve
+        uint256 balance = ERC20(_token).balanceOf(_wallet);
+        require(balance >= _amount, "BT: insufficient balance");
+
         uint256 existingAllowance = ERC20(_token).allowance(_wallet, _spender);
         uint256 totalAllowance = SafeMath.add(existingAllowance, _amount);
         // Approve the desired amount plus existing amount. This logic allows for potential gas saving later

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -813,5 +813,19 @@ describe("TransferManager", function () {
         assert.ok(await manager.isRevertReason(error, "above daily limit"));
       }
     });
+
+    it("should fail to approve token if the amount to be approved is greater than the current balance", async () => {
+      const startingBalance = await erc20.balanceOf(wallet.contractAddress);
+      await erc20.burn(wallet.contractAddress, startingBalance);
+      const dataToTransfer = contract.contract.interface.functions.setStateAndPayToken.encode([3, erc20.contractAddress, 1]);
+      await assert.revertWith(transferModule.from(owner).approveTokenAndCallContract(
+        wallet.contractAddress,
+        erc20.contractAddress,
+        contract.contractAddress,
+        1,
+        contract.contractAddress,
+        dataToTransfer,
+      ), "BT: insufficient balance");
+    });
   });
 });


### PR DESCRIPTION
Adds a check in `approveTokenAndCallContract` to ensure there is sufficient balance to cover the required amount, before proceeding with the approve-and-call logic.