### PR TITLE
Change and reset daily limit with guardians.

### DIFF
--- a/contracts-test/TestLimitModule.sol
+++ b/contracts-test/TestLimitModule.sol
@@ -45,6 +45,11 @@ contract TestLimitModule is BaseModule {
         return dailySpent.alreadySpent;
     }
 
+    function getLimit(address _wallet) external view returns (uint256) {
+        ILimitStorage.Limit memory limit = limitStorage.getLimit(_wallet);
+        return limit.current;
+    }
+
     function getRequiredSignatures(address _wallet, bytes calldata _data) external view override returns (uint256, OwnerSignature) {
         return (1, OwnerSignature.Required);
     }

--- a/contracts/modules/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer.sol
@@ -128,7 +128,7 @@ contract ApprovedTransfer is BaseTransfer {
         // solium-disable-next-line security/no-block-members
         ILimitStorage.Limit memory newLimit = ILimitStorage.Limit(targetLimit, targetLimit, LimitUtils.safe64(now));
         // solium-disable-next-line security/no-block-members
-        ILimitStorage.DailySpent memory resetDailySpent = ILimitStorage.DailySpent(uint128(0), LimitUtils.safe64(now));
+        ILimitStorage.DailySpent memory resetDailySpent = ILimitStorage.DailySpent(uint128(0), uint64(0));
         // change limit and reset daily spent in one call
         limitStorage.setLimitAndDailySpent(_wallet, newLimit, resetDailySpent);
         emit LimitChanged(_wallet, _newLimit, newLimit.changeAfter);

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -74,7 +74,6 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     address token, address to, uint256 amount, bytes data);
     event PendingTransferExecuted(address indexed wallet, bytes32 indexed id);
     event PendingTransferCanceled(address indexed wallet, bytes32 indexed id);
-    event LimitChanged(address indexed wallet, uint indexed newLimit, uint64 indexed startAfter);
 
     // *************** Constructor ********************** //
 

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -380,7 +380,8 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
      * @param _newLimit The new limit.
      */
     function changeLimit(address _wallet, uint256 _newLimit) external onlyWalletOwnerOrModule(_wallet) onlyWhenUnlocked(_wallet) {
-        LimitUtils.changeLimit(limitStorage, _wallet, _newLimit, securityPeriod);
+        ILimitStorage.Limit memory limit = LimitUtils.changeLimit(limitStorage, _wallet, _newLimit, securityPeriod);
+        emit LimitChanged(_wallet, _newLimit, limit.changeAfter);
     }
 
     /**

--- a/contracts/modules/common/BaseTransfer.sol
+++ b/contracts/modules/common/BaseTransfer.sol
@@ -21,7 +21,7 @@ import "./LimitUtils.sol";
 
 /**
  * @title BaseTransfer
- * @dev Module containing internal methods to execute or approve transfers
+ * @dev Module containing internal methods to transfer tokens or call third-party contracts.
  * @author Olivier VDB - <olivier@argent.xyz>
  */
 abstract contract BaseTransfer is BaseModule {
@@ -40,6 +40,8 @@ abstract contract BaseTransfer is BaseModule {
         uint256 amountSpent,
         bytes data
     );
+    event LimitChanged(address indexed wallet, uint indexed newLimit, uint64 indexed startAfter);
+
     // *************** Internal Functions ********************* //
     /**
     * @notice Make sure a contract call is not trying to call a module, the wallet itself, or a supported ERC20.

--- a/contracts/modules/common/LimitUtils.sol
+++ b/contracts/modules/common/LimitUtils.sol
@@ -130,12 +130,11 @@ library LimitUtils {
     }
 
     /**
-    * @dev Helper method to Reset the daily consumption, i.e. DailySpent.alreadySpent = 0 and DailySpent.periodEnd = now.
+    * @dev Helper method to Reset the daily consumption.
     * @param _wallet The target wallet.
     */
     function resetDailySpent(ILimitStorage _lStorage, address _wallet) internal {
-        // solium-disable-next-line security/no-block-members
-        _lStorage.setDailySpent(_wallet, ILimitStorage.DailySpent(uint128(0), safe64(now)));
+        _lStorage.setDailySpent(_wallet, ILimitStorage.DailySpent(uint128(0), uint64(0)));
     }
 
     /**

--- a/deployment/2_deploy_contracts.js
+++ b/deployment/2_deploy_contracts.js
@@ -45,7 +45,11 @@ const deploy = async (network) => {
   // Deploy the MultiSig
   const MultiSigWrapper = await deployer.deploy(MultiSig, {}, newConfig.multisig.threshold, newConfig.multisig.owners);
   // Deploy TokenPriceProvider
-  const TokenPriceProviderWrapper = await deployer.deploy(TokenPriceProvider, {}, newConfig.Kyber.contract);
+  const TokenPriceProviderWrapper = await deployer.deploy(
+    TokenPriceProvider,
+    {},
+    newConfig.Kyber ? newConfig.Kyber.contract : "0x0000000000000000000000000000000000000000",
+  );
   // Deploy Module Registry
   const ModuleRegistryWrapper = await deployer.deploy(ModuleRegistry);
   // Deploy Compound Registry

--- a/deployment/5_deploy_modules.js
+++ b/deployment/5_deploy_modules.js
@@ -100,7 +100,7 @@ const deploy = async (network) => {
     {},
     config.contracts.ModuleRegistry,
     GuardianStorageWrapper.contractAddress,
-    config.Kyber.contract,
+    config.Kyber ? config.Kyber.contract : "0x0000000000000000000000000000000000000000",
     config.contracts.MultiSigWallet,
     config.settings.feeRatio || 0,
   );

--- a/deployment/7_upgrade_2_0.js
+++ b/deployment/7_upgrade_2_0.js
@@ -95,6 +95,7 @@ const deploy = async (network) => {
     {},
     config.contracts.ModuleRegistry,
     config.modules.GuardianStorage,
+    LimitStorageWrapper.contractAddress,
   );
   newModuleWrappers.push(ApprovedTransferWrapper);
 

--- a/deployment/999_benchmark.js
+++ b/deployment/999_benchmark.js
@@ -160,27 +160,27 @@ class Benchmark {
   // ///////////////////
 
   async estimateCreateWalletOneModule() {
-    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.oneModule, "hoy");
+    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.oneModule, "", this.accounts[5]);
     this._logger.addItem("Create a wallet without ENS (1 module)", gasUsed);
   }
 
   async estimateCreateWalletTwoModules() {
-    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.twoModules, "heya");
+    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.twoModules, "", this.accounts[4]);
     this._logger.addItem("Create a wallet without ENS (2 module)", gasUsed);
   }
 
   async estimateCreateWalletThreeModules() {
-    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.threeModules, "meh");
+    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.threeModules, "", this.accounts[4]);
     this._logger.addItem("Create a wallet without ENS (3 module)", gasUsed);
   }
 
   async estimateCreateWalletAllModules() {
-    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.allModules, "moo");
+    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.allModules, "", this.accounts[4]);
     this._logger.addItem("Create a wallet without ENS (all modules)", gasUsed);
   }
 
   async estimateCreateWalletWithENS() {
-    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.allModules, "helloworld");
+    const gasUsed = await this.WalletFactoryWrapper.estimate.createWallet(this.accounts[4], this.allModules, "helloworld", this.accounts[4]);
     this._logger.addItem("Create a wallet with ENS (all modules)", gasUsed);
   }
 

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -369,7 +369,7 @@ describe("Approved Transfer", function () {
     it("should reset the daily consumption", async () => {
       let dailySpent = await limitModule.getDailySpent(wallet.contractAddress);
       assert.equal(dailySpent.toNumber(), 500, "dailySpent should be 500");
-      await manager.relay(approvedTransfer, "resetLimit", [wallet.contractAddress], wallet, [owner, guardian1]);
+      await manager.relay(approvedTransfer, "resetDailySpent", [wallet.contractAddress], wallet, [owner, guardian1]);
       dailySpent = await limitModule.getDailySpent(wallet.contractAddress);
       assert.equal(dailySpent.toNumber(), 0, "dailySpent should be 0");
     });

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -6,10 +6,12 @@ const BaseWallet = require("../build/BaseWallet");
 const RelayerModule = require("../build/RelayerModule");
 const Registry = require("../build/ModuleRegistry");
 const GuardianStorage = require("../build/GuardianStorage");
+const LimitStorage = require("../build/LimitStorage");
 const GuardianManager = require("../build/GuardianManager");
 const ApprovedTransfer = require("../build/ApprovedTransfer");
 const ERC20 = require("../build/TestERC20");
 const TestContract = require("../build/TestContract");
+const TestLimitModule = require("../build/TestLimitModule");
 
 const TestManager = require("../utils/test-manager");
 const { sortWalletByAddress, parseRelayReceipt, ETH_TOKEN } = require("../utils/utilities.js");
@@ -36,30 +38,44 @@ describe("Approved Transfer", function () {
   let walletImplementation;
   let guardianManager;
   let approvedTransfer;
+  let limitModule;
   let relayerModule;
   let erc20;
   const amountToTransfer = 10000;
+  let contract;
 
   before(async () => {
     deployer = manager.newDeployer();
     const registry = await deployer.deploy(Registry);
     const guardianStorage = await deployer.deploy(GuardianStorage);
+    const limitStorage = await deployer.deploy(LimitStorage);
     guardianManager = await deployer.deploy(GuardianManager, {}, registry.contractAddress, guardianStorage.contractAddress, 24, 12);
-    approvedTransfer = await deployer.deploy(ApprovedTransfer, {}, registry.contractAddress, guardianStorage.contractAddress);
+    approvedTransfer = await deployer.deploy(ApprovedTransfer, {},
+      registry.contractAddress,
+      guardianStorage.contractAddress,
+      limitStorage.contractAddress);
     relayerModule = await deployer.deploy(RelayerModule, {},
       registry.contractAddress,
       guardianStorage.contractAddress,
-      ethers.constants.AddressZero,
+      limitStorage.contractAddress,
       ethers.constants.AddressZero);
     manager.setRelayerModule(relayerModule);
     walletImplementation = await deployer.deploy(BaseWallet);
+
+    limitModule = await deployer.deploy(TestLimitModule, {}, registry.contractAddress, guardianStorage.contractAddress, limitStorage.contractAddress);
   });
 
   beforeEach(async () => {
     const proxy = await deployer.deploy(Proxy, {}, walletImplementation.contractAddress);
     wallet = deployer.wrapDeployedContract(BaseWallet, proxy.contractAddress);
 
-    await wallet.init(owner.address, [approvedTransfer.contractAddress, guardianManager.contractAddress, relayerModule.contractAddress]);
+    await wallet.init(owner.address,
+      [
+        approvedTransfer.contractAddress,
+        guardianManager.contractAddress,
+        relayerModule.contractAddress,
+        limitModule.contractAddress,
+      ]);
 
     const decimals = 12; // number of decimal for TOKN contract
     erc20 = await deployer.deploy(ERC20, {}, [infrastructure.address, wallet.contractAddress], 10000000, decimals); // TOKN contract with 10M tokens (5M TOKN for wallet and 5M TOKN for account[0])
@@ -95,16 +111,27 @@ describe("Approved Transfer", function () {
     return wallets;
   }
 
-  describe("Transfer", () => {
-    async function transferToken(_token, _signers) {
-      const to = recipient.address;
-      const before = _token === ETH_TOKEN ? await deployer.provider.getBalance(to) : await erc20.balanceOf(to);
-      await manager.relay(approvedTransfer, "transferToken",
-        [wallet.contractAddress, _token, to, amountToTransfer, ZERO_BYTES32], wallet, _signers);
-      const after = _token === ETH_TOKEN ? await deployer.provider.getBalance(to) : await erc20.balanceOf(to);
-      assert.equal(after.sub(before).toNumber(), amountToTransfer, "should have transfered the amount");
-    }
+  async function transferToken(_token, _signers) {
+    const to = recipient.address;
+    const before = _token === ETH_TOKEN ? await deployer.provider.getBalance(to) : await erc20.balanceOf(to);
+    await manager.relay(approvedTransfer, "transferToken",
+      [wallet.contractAddress, _token, to, amountToTransfer, ZERO_BYTES32], wallet, _signers);
+    const after = _token === ETH_TOKEN ? await deployer.provider.getBalance(to) : await erc20.balanceOf(to);
+    assert.equal(after.sub(before).toNumber(), amountToTransfer, "should have transfered the amount");
+  }
 
+  async function callContract(_signers) {
+    const before = await deployer.provider.getBalance(contract.contractAddress);
+    const newState = parseInt((await contract.state()).toString(), 10) + 1;
+    const dataToTransfer = contract.contract.interface.functions.setState.encode([newState]);
+    await manager.relay(approvedTransfer, "callContract",
+      [wallet.contractAddress, contract.contractAddress, amountToTransfer, dataToTransfer], wallet, _signers);
+    const after = await deployer.provider.getBalance(contract.contractAddress);
+    assert.equal(after.sub(before).toNumber(), amountToTransfer, "should have transfered the ETH amount");
+    assert.equal((await contract.state()).toNumber(), newState, "the state of the external contract should have been changed");
+  }
+
+  describe("Transfer", () => {
     async function expectFailingTransferToken(_token, _signers, _reason) {
       await assert.revertWith(
         manager.relay(
@@ -216,24 +243,11 @@ describe("Approved Transfer", function () {
 
   describe("Contract call", () => {
     describe("Approved by 1 EOA and 2 smart-contract guardians", () => {
-      let contract;
-
       beforeEach(async () => {
         contract = await deployer.deploy(TestContract);
         assert.equal(await contract.state(), 0, "initial contract state should be 0");
         await addGuardians([guardian1, ...(await createSmartContractGuardians([guardian2, guardian3]))]);
       });
-
-      async function callContract(_signers) {
-        const before = await deployer.provider.getBalance(contract.contractAddress);
-        const newState = parseInt((await contract.state()).toString(), 10) + 1;
-        const dataToTransfer = contract.contract.interface.functions.setState.encode([newState]);
-        await manager.relay(approvedTransfer, "callContract",
-          [wallet.contractAddress, contract.contractAddress, amountToTransfer, dataToTransfer], wallet, _signers);
-        const after = await deployer.provider.getBalance(contract.contractAddress);
-        assert.equal(after.sub(before).toNumber(), amountToTransfer, "should have transfered the ETH amount");
-        assert.equal((await contract.state()).toNumber(), newState, "the state of the external contract should have been changed");
-      }
 
       it("should call a contract and transfer ETH with 1 EOA guardian and 2 smart-contract guardians", async () => {
         await callContract([owner, ...sortWalletByAddress([guardian1, guardian2])]);
@@ -255,7 +269,6 @@ describe("Approved Transfer", function () {
 
   describe("Approve token and Contract call", () => {
     describe("Approved by 1 EOA and 2 smart-contract guardians", () => {
-      let contract;
       const amountToApprove = 10000;
 
       beforeEach(async () => {
@@ -336,6 +349,45 @@ describe("Approved Transfer", function () {
           assert.equal(allowanceAfter.toNumber(), allowanceBefore.toNumber());
         });
       });
+    });
+  });
+
+  describe("Daily Limit", () => {
+    beforeEach(async () => {
+      await addGuardians([guardian1]);
+      await limitModule.setLimitAndDailySpent(wallet.contractAddress, 1000000, 500);
+    });
+
+    it("should change the limit immediately", async () => {
+      let limit = await limitModule.getLimit(wallet.contractAddress);
+      assert.equal(limit.toNumber(), 1000000, "limit should be 1000000");
+      await manager.relay(approvedTransfer, "changeLimit", [wallet.contractAddress, 4000000], wallet, [owner, guardian1]);
+      limit = await limitModule.getLimit(wallet.contractAddress);
+      assert.equal(limit.toNumber(), 4000000, "limit should be changed immediately");
+    });
+
+    it("should reset the daily consumption", async () => {
+      let dailySpent = await limitModule.getDailySpent(wallet.contractAddress);
+      assert.equal(dailySpent.toNumber(), 500, "dailySpent should be 500");
+      await manager.relay(approvedTransfer, "resetLimit", [wallet.contractAddress], wallet, [owner, guardian1]);
+      dailySpent = await limitModule.getDailySpent(wallet.contractAddress);
+      assert.equal(dailySpent.toNumber(), 0, "dailySpent should be 0");
+    });
+
+    it("should reset the daily consumption after a transfer", async () => {
+      let dailySpent = await limitModule.getDailySpent(wallet.contractAddress);
+      assert.equal(dailySpent.toNumber(), 500, "dailySpent should be 500");
+      await transferToken(ETH_TOKEN, [owner, guardian1]);
+      dailySpent = await limitModule.getDailySpent(wallet.contractAddress);
+      assert.equal(dailySpent.toNumber(), 0, "dailySpent should be 0");
+    });
+
+    it("should reset the daily consumption after a call contract", async () => {
+      let dailySpent = await limitModule.getDailySpent(wallet.contractAddress);
+      assert.equal(dailySpent.toNumber(), 500, "dailySpent should be 500");
+      await callContract([owner, guardian1]);
+      dailySpent = await limitModule.getDailySpent(wallet.contractAddress);
+      assert.equal(dailySpent.toNumber(), 0, "dailySpent should be 0");
     });
   });
 });


### PR DESCRIPTION
We add 2 new methods to the `ApprovedTransfer` to simplify the management of the daily limit:
- `changeLimit` to change the current value of the daily limit immediately when approved by guardians
- `resetLimit` to reset the daily consumption to 0 immediately when approved by guardians.

We also make the following changes:
- Every action on the `ApprovedTransfer` module resets the daily consumption to 0 (calls `resetLimit` internally).
- On the `TransferManager` decreasing the daily limit becomes immediate, while increasing the limit remains pending for the duration of the security period. 