### PR TITLE
Fix CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
           name: "Lint Solidity contracts"
           command: npm run lint:contracts
       - run:
+          name: "Testing deployment scripts and benchmark gas costs"
+          command: npm run ganache >/dev/null 2>&1 & npm run test:deployment && npm run test:benchmark
+      - run:
           name: "Compiling external library contracts"
           command: npm run compile:lib
       - run:
@@ -55,9 +58,6 @@ jobs:
       - run:
           name: "Lint JavaScript"
           command: npm run lint:js
-      - run:
-          name: "Testing deployment scripts and benchmark gas costs"
-          command: npm run ganache >/dev/null 2>&1 & npm run test:deployment && npm run test:benchmark
       - run:
           name: "Running unit tests"
           command: npm run ganache >/dev/null 2>&1 & npm run test

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,10 +24,12 @@ fi
 rm -rf build
 npm run compile:lib
 npm run compile
+npm run compile:legacy
 
 for IDX in "$@"
 do
     FILE=`ls ./deployment/${IDX}_*.js`
+    echo "Deployment file: $FILE"
     if [ ! -z "${CI:-}" ]; then
         echo "Waiting for ganache to launch on port 8545..."
         while ! nc -z localhost 8545; do sleep 1; done


### PR DESCRIPTION
We reorder commands in CI as `test:deployment` removes the built contracts and only compiles a subset of them before it runs, leaving the state incomplete for unit tests after, causing build to fail, e.g: https://app.circleci.com/jobs/github/argentlabs/argent-contracts/1217