### PR TITLE
Upgrade to solc 0.6.12

### DIFF
--- a/contracts-test/BadModule.sol
+++ b/contracts-test/BadModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 import "../contracts/modules/common/BaseModule.sol";
 
 contract BadModule is BaseModule {

--- a/contracts-test/ERC20Approver.sol
+++ b/contracts-test/ERC20Approver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 import "../contracts/wallet/BaseWallet.sol";
 import "../contracts/modules/common/OnlyOwnerModule.sol";
 

--- a/contracts-test/FakeWallet.sol
+++ b/contracts-test/FakeWallet.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 import "../contracts/modules/common/IModule.sol";
 import "../contracts/wallet/IWallet.sol";
 

--- a/contracts-test/KyberNetworkTest.sol
+++ b/contracts-test/KyberNetworkTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 import "../lib/other/ERC20.sol";
 import "../lib/other/KyberNetwork.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts-test/NonCompliantERC20.sol
+++ b/contracts-test/NonCompliantERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 

--- a/contracts-test/NonCompliantGuardian.sol
+++ b/contracts-test/NonCompliantGuardian.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 /**
  * @title NonCompliantGuardian

--- a/contracts-test/TestContract.sol
+++ b/contracts-test/TestContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 import "./TokenConsumer.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts-test/TestERC20.sol
+++ b/contracts-test/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts-test/TestERC721.sol
+++ b/contracts-test/TestERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/contracts-test/TestLimitModule.sol
+++ b/contracts-test/TestLimitModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts-test/TestModule.sol
+++ b/contracts-test/TestModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 import "../contracts/modules/common/BaseModule.sol";
 import "./TestDapp.sol";
 

--- a/contracts-test/TestOnlyOwnerModule.sol
+++ b/contracts-test/TestOnlyOwnerModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "../contracts/modules/common/OnlyOwnerModule.sol";
 

--- a/contracts-test/TestRegistry.sol
+++ b/contracts-test/TestRegistry.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Source https://github.com/christianlundkvist/simple-multisig/blob/master/contracts/TestRegistry.sol
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 // This contract is only used for testing the MultiSigWallet
 contract TestRegistry {

--- a/contracts-test/TestUpgradedMakerV2Manager.sol
+++ b/contracts-test/TestUpgradedMakerV2Manager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "../contracts/modules/maker/MakerV2Manager.sol";
 

--- a/contracts-test/TokenConsumer.sol
+++ b/contracts-test/TokenConsumer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts-test/maker/FaucetUser.sol
+++ b/contracts-test/maker/FaucetUser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "../../lib/maker/DS/IERC20.sol";
 

--- a/contracts-test/maker/TestCdpManager.sol
+++ b/contracts-test/maker/TestCdpManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 abstract contract TestCdpManager {
     function urns(uint) public virtual view returns (address);

--- a/contracts-test/uniswapV2/uniswap-V2-periphery/UniswapV2Router01.sol
+++ b/contracts-test/uniswapV2/uniswap-V2-periphery/UniswapV2Router01.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import '@uniswap/lib/contracts/libraries/TransferHelper.sol';
 

--- a/contracts-test/uniswapV2/uniswap-V2-periphery/libraries/SafeMath.sol
+++ b/contracts-test/uniswapV2/uniswap-V2-periphery/libraries/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 // a library for performing overflow-safe math, courtesy of DappHub (https://github.com/dapphub/ds-math)
 

--- a/contracts/infrastructure/WalletFactory.sol
+++ b/contracts/infrastructure/WalletFactory.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "../wallet/Proxy.sol";
 import "../wallet/BaseWallet.sol";

--- a/contracts/infrastructure/storage/ILimitStorage.sol
+++ b/contracts/infrastructure/storage/ILimitStorage.sol
@@ -12,7 +12,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/contracts/infrastructure/storage/ITokenPriceStorage.sol
+++ b/contracts/infrastructure/storage/ITokenPriceStorage.sol
@@ -12,7 +12,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 /**
  * @title ITokenPriceStorage

--- a/contracts/infrastructure/storage/LimitStorage.sol
+++ b/contracts/infrastructure/storage/LimitStorage.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./ILimitStorage.sol";

--- a/contracts/infrastructure/storage/TokenPriceStorage.sol
+++ b/contracts/infrastructure/storage/TokenPriceStorage.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./ITokenPriceStorage.sol";
 import "./Storage.sol";

--- a/contracts/modules/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./common/Utils.sol";

--- a/contracts/modules/CompoundManager.sol
+++ b/contracts/modules/CompoundManager.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./common/OnlyOwnerModule.sol";
 import "../infrastructure/ICompoundRegistry.sol";

--- a/contracts/modules/GuardianManager.sol
+++ b/contracts/modules/GuardianManager.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./common/Utils.sol";
 import "./common/GuardianUtils.sol";

--- a/contracts/modules/LockManager.sol
+++ b/contracts/modules/LockManager.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./common/BaseModule.sol";
 import "./common/GuardianUtils.sol";

--- a/contracts/modules/NftTransfer.sol
+++ b/contracts/modules/NftTransfer.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./common/OnlyOwnerModule.sol";
 

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./common/Utils.sol";
 import "./common/BaseModule.sol";

--- a/contracts/modules/RelayerModule.sol
+++ b/contracts/modules/RelayerModule.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./common/Utils.sol";

--- a/contracts/modules/SimpleUpgrader.sol
+++ b/contracts/modules/SimpleUpgrader.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./common/BaseModule.sol";
 

--- a/contracts/modules/TokenExchanger.sol
+++ b/contracts/modules/TokenExchanger.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./common/OnlyOwnerModule.sol";

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./common/Utils.sol";

--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../../wallet/IWallet.sol";

--- a/contracts/modules/common/BaseTransfer.sol
+++ b/contracts/modules/common/BaseTransfer.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./BaseModule.sol";
 import "./LimitUtils.sol";

--- a/contracts/modules/common/GuardianUtils.sol
+++ b/contracts/modules/common/GuardianUtils.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 library GuardianUtils {
 

--- a/contracts/modules/common/LimitUtils.sol
+++ b/contracts/modules/common/LimitUtils.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/modules/common/OnlyOwnerModule.sol
+++ b/contracts/modules/common/OnlyOwnerModule.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./BaseModule.sol";
 

--- a/contracts/modules/common/Utils.sol
+++ b/contracts/modules/common/Utils.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 /**
  * @title Utils

--- a/contracts/modules/maker/IUniswapExchange.sol
+++ b/contracts/modules/maker/IUniswapExchange.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 interface IUniswapExchange {
     function getEthToTokenOutputPrice(uint256 _tokensBought) external view returns (uint256);

--- a/contracts/modules/maker/IUniswapFactory.sol
+++ b/contracts/modules/maker/IUniswapFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 interface IUniswapFactory {
     function getExchange(address _token) external view returns(address);

--- a/contracts/modules/maker/MakerV2Base.sol
+++ b/contracts/modules/maker/MakerV2Base.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "../common/BaseModule.sol";
 import "../common/OnlyOwnerModule.sol";

--- a/contracts/modules/maker/MakerV2Invest.sol
+++ b/contracts/modules/maker/MakerV2Invest.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./MakerV2Base.sol";
 

--- a/contracts/modules/maker/MakerV2Loan.sol
+++ b/contracts/modules/maker/MakerV2Loan.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./MakerV2Base.sol";
 import "./IUniswapExchange.sol";

--- a/contracts/modules/maker/MakerV2Manager.sol
+++ b/contracts/modules/maker/MakerV2Manager.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "./MakerV2Base.sol";
 import "./MakerV2Invest.sol";

--- a/contracts/wallet/BaseWallet.sol
+++ b/contracts/wallet/BaseWallet.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 import "../modules/common/IModule.sol";
 import "./IWallet.sol";

--- a/contracts/wallet/Proxy.sol
+++ b/contracts/wallet/Proxy.sol
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 
 /**
  * @title Proxy

--- a/package-lock.json
+++ b/package-lock.json
@@ -700,7 +700,7 @@
             "eth-lib": "0.2.7",
             "ethereumjs-common": "^1.3.2",
             "ethereumjs-tx": "^2.1.1",
-            "scrypt-shim": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
+            "scrypt-shim": "github:web3-js/scrypt-shim",
             "underscore": "1.9.1",
             "uuid": "3.3.2",
             "web3-core": "1.2.2",
@@ -822,7 +822,7 @@
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.2",
-            "websocket": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400"
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -1388,7 +1388,7 @@
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
-            "websocket": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400"
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -1630,7 +1630,8 @@
     "acorn": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+      "optional": true
     },
     "acorn-globals": {
       "version": "1.0.9",
@@ -2997,7 +2998,8 @@
     "cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "optional": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -4143,8 +4145,8 @@
         "axios": "^0.18.0",
         "bn": "^1.0.1",
         "chai": "4.1.2",
-        "circom": "github:LimeChain/circom#4ae2447b97d558820a7c7817d602185478ad0b92",
-        "cli-analytics-sdk": "github:LimeChain/cli-analytics-sdk#a6889825b171d1a146936b13287357c93b5535b9",
+        "circom": "github:LimeChain/circom",
+        "cli-analytics-sdk": "github:LimeChain/cli-analytics-sdk",
         "cli-table": "0.3.1",
         "colors": "1.3.2",
         "docker-cli-js": "^2.5.2",
@@ -4160,7 +4162,7 @@
         "original-require": "1.0.1",
         "require-from-string": "2.0.2",
         "simple-git": "^1.107.0",
-        "snarkjs": "github:LimeChain/snarkjs#f7036ebe9bfa3f3817077f050780c8ec1542e249",
+        "snarkjs": "github:LimeChain/snarkjs",
         "solc": "^0.6.1",
         "solidity-coverage": "^0.7.7",
         "tcp-port-used": "^1.0.1",
@@ -4200,7 +4202,7 @@
         "etherlime-config": "^1.0.0",
         "etherlime-logger": "^1.1.2",
         "etherlime-utils": "^1.1.2",
-        "ethers": "git+https://github.com/LimeChain/ethers.js.git#7eceb12e0a05ed1e44834556f6a32e20918abf1b",
+        "ethers": "git+https://github.com/LimeChain/ethers.js.git#master",
         "typescript": "^3.5.1"
       },
       "dependencies": {
@@ -9113,9 +9115,9 @@
       }
     },
     "solc": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.6.10.tgz",
-      "integrity": "sha512-+oHwIvNjg3bxXvL9yua/Z4ZFEdkCkgRSh7aIGGb+mf/gzoA8PRKiKGYDsjMaj0CJLH1BTBOUpNFeYhhnUFfjRg==",
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.6.12.tgz",
+      "integrity": "sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==",
       "requires": {
         "command-exists": "^1.2.8",
         "commander": "3.0.2",
@@ -12049,7 +12051,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "openzeppelin-solidity": "2.3",
     "ps-node": "^0.1.6",
     "semver": "^7.1.3",
-    "solc": "0.6.10",
+    "solc": "0.6.12",
     "solhint": "^3.0.0",
     "tinyreq": "^3.4.1",
     "web3-eth-abi": "^1.2.9"


### PR DESCRIPTION
Upgrade contracts to the latest solc release 0.6.12 https://github.com/ethereum/solidity/releases/tag/v0.6.12

Notable changes for us include:
- Evaluate `keccak256` of string literals at compile-time - this will bring some gas savings
- Type Checker: Fix overload resolution in combination with {value: ...} - potentially important for `Wallet.invoke()`
- NatSpec: Implement tag @inheritdoc to copy documentation from a specific base contract.