### PR TITLE
re-introduce getGuardians() method in GuardianManager.sol

### DIFF
--- a/contracts/modules/GuardianManager.sol
+++ b/contracts/modules/GuardianManager.sol
@@ -201,6 +201,15 @@ contract GuardianManager is BaseModule {
     }
 
     /**
+     * @notice Get the active guardians for a wallet.
+     * @param _wallet The target wallet.
+     * @return _guardians the active guardians for a wallet.
+     */
+    function getGuardians(address _wallet) external view returns (address[] memory _guardians) {
+        return guardianStorage.getGuardians(_wallet);
+    }
+
+    /**
      * @inheritdoc IModule
      */
     function getRequiredSignatures(address _wallet, bytes calldata _data) external view override returns (uint256, OwnerSignature) {

--- a/deployment/7_upgrade_2_0.js
+++ b/deployment/7_upgrade_2_0.js
@@ -252,8 +252,7 @@ const deploy = async (network) => {
   await configurator.save();
 
   await Promise.all([
-    abiUploader.upload(LimitStorageWrapper, "contracts"),
-    abiUploader.upload(TokenPriceStorageWrapper, "contracts"),
+    abiUploader.upload(LimitStorageWrapper, "modules"),
     abiUploader.upload(ApprovedTransferWrapper, "modules"),
     abiUploader.upload(CompoundManagerWrapper, "modules"),
     abiUploader.upload(GuardianManagerWrapper, "modules"),
@@ -264,6 +263,7 @@ const deploy = async (network) => {
     abiUploader.upload(MakerV2ManagerWrapper, "modules"),
     abiUploader.upload(TransferManagerWrapper, "modules"),
     abiUploader.upload(RelayerModuleWrapper, "modules"),
+    abiUploader.upload(TokenPriceStorageWrapper, "contracts"),
     abiUploader.upload(BaseWalletWrapper, "contracts"),
     abiUploader.upload(WalletFactoryWrapper, "contracts"),
   ]);

--- a/deployment/7_upgrade_2_0.js
+++ b/deployment/7_upgrade_2_0.js
@@ -26,7 +26,7 @@ const ENSManager = require("../build/ArgentENSManager");
 
 const utils = require("../utils/utilities.js");
 
-const TARGET_VERSION = "2.0.0";
+const TARGET_VERSION = "2.0.1";
 const MODULES_TO_ENABLE = [
   "ApprovedTransfer",
   "CompoundManager",
@@ -252,15 +252,15 @@ const deploy = async (network) => {
   await configurator.save();
 
   await Promise.all([
-    abiUploader.upload(LimitStorageWrapper, "modules"),
+    abiUploader.upload(LimitStorageWrapper, "contracts"),
     abiUploader.upload(TokenPriceStorageWrapper, "contracts"),
     abiUploader.upload(ApprovedTransferWrapper, "modules"),
     abiUploader.upload(CompoundManagerWrapper, "modules"),
-    abiUploader.upload(GuardianManagerWrapper, "contracts"),
-    abiUploader.upload(LockManagerWrapper, "contracts"),
-    abiUploader.upload(NftTransferWrapper, "contracts"),
+    abiUploader.upload(GuardianManagerWrapper, "modules"),
+    abiUploader.upload(LockManagerWrapper, "modules"),
+    abiUploader.upload(NftTransferWrapper, "modules"),
     abiUploader.upload(RecoveryManagerWrapper, "modules"),
-    abiUploader.upload(TokenExchangerWrapper, "contracts"),
+    abiUploader.upload(TokenExchangerWrapper, "modules"),
     abiUploader.upload(MakerV2ManagerWrapper, "modules"),
     abiUploader.upload(TransferManagerWrapper, "modules"),
     abiUploader.upload(RelayerModuleWrapper, "modules"),

--- a/test/guardianManager.js
+++ b/test/guardianManager.js
@@ -70,8 +70,11 @@ describe("GuardianManager", function () {
         await guardianManager.confirmGuardianAddition(wallet.contractAddress, guardian2.address);
         count = (await guardianStorage.guardianCount(wallet.contractAddress)).toNumber();
         active = await guardianManager.isGuardian(wallet.contractAddress, guardian2.address);
+        const guardians = await guardianManager.getGuardians(wallet.contractAddress);
         assert.isTrue(active, "second guardian should be active");
         assert.equal(count, 2, "2 guardians should be active after security period");
+        assert.equal(guardian1.address, guardians[0], "should return first guardian address");
+        assert.equal(guardian2.address, guardians[1], "should return second guardian address");
       });
 
       it("should not let the owner add EOA Guardians after two security periods (blockchain transaction)", async () => {


### PR DESCRIPTION
The `view` method `getGuardians` was removed from the `GuardianManager` in a previous PR but is used by the mobile clients. This PR re-introduces the deleted method.

It also fixes some inconsistencies related to where some contracts ABI are stored on S3.