### PR TITLE
Addressing Trail of Bits' audit

### DIFF
--- a/contracts/infrastructure/storage/ITokenPriceStorage.sol
+++ b/contracts/infrastructure/storage/ITokenPriceStorage.sol
@@ -19,12 +19,6 @@ pragma solidity ^0.6.12;
  * @notice TokenPriceStorage interface
  */
 interface ITokenPriceStorage {
-
-    function getTokenPrice(address _token) external view returns (uint256 _price);
-
-    function getPriceForTokenList(address[] calldata _tokens) external view returns (uint256[] memory _prices);
-
-    function setPriceForTokenList(address[] calldata _tokens, uint256[] calldata _prices) external;
-
-    function setPrice(address _token, uint256 _price) external;
+    function getTokenPrice(address _token) external view returns (uint184 _price);
+    function isTokenTradable(address _token) external view returns (bool _isTradable);
 }

--- a/contracts/infrastructure/storage/TokenPriceStorage.sol
+++ b/contracts/infrastructure/storage/TokenPriceStorage.sol
@@ -23,7 +23,7 @@ import "../base/Managed.sol";
 /**
  * @title TokenPriceStorage
  * @notice Contract storing the token prices.
- * @notice Note that prices stored here = price per token * 10^(36-token decimals)
+ * @notice Note that prices stored here = price per token * 10^(18-token decimals)
  * The contract only defines basic setters and getters with no logic.
  * Only managers of this contract can modify its state.
  */

--- a/contracts/infrastructure/storage/TokenPriceStorage.sol
+++ b/contracts/infrastructure/storage/TokenPriceStorage.sol
@@ -50,13 +50,13 @@ contract TokenPriceStorage is ITokenPriceStorage, Storage, Managed {
     }
     function getPriceForTokenList(address[] calldata _tokens) external view returns (uint184[] memory _prices) {
         _prices = new uint184[](_tokens.length);
-        for (uint i = 0; i < _tokens.length; i++) {
+        for (uint256 i = 0; i < _tokens.length; i++) {
             _prices[i] = tokenInfo[_tokens[i]].cachedPrice;
         }
     }
     function getTradableForTokenList(address[] calldata _tokens) external view returns (bool[] memory _tradable) {
         _tradable = new bool[](_tokens.length);
-        for (uint i = 0; i < _tokens.length; i++) {
+        for (uint256 i = 0; i < _tokens.length; i++) {
             _tradable[i] = tokenInfo[_tokens[i]].isTradable;
         }
     }
@@ -67,7 +67,8 @@ contract TokenPriceStorage is ITokenPriceStorage, Storage, Managed {
         minPriceUpdatePeriod = _newPeriod;
     }
     function setPriceForTokenList(address[] calldata _tokens, uint184[] calldata _prices) external onlyManager {
-        for (uint16 i = 0; i < _tokens.length; i++) {
+        require(_tokens.length == _prices.length, "TPS: Array length mismatch");
+        for (uint i = 0; i < _tokens.length; i++) {
             uint64 updatedAt = tokenInfo[_tokens[i]].updatedAt;
             require(updatedAt == 0 || block.timestamp >= updatedAt + minPriceUpdatePeriod, "TPS: Price updated too early");
             tokenInfo[_tokens[i]].cachedPrice = _prices[i];
@@ -75,7 +76,8 @@ contract TokenPriceStorage is ITokenPriceStorage, Storage, Managed {
         }
     }
     function setTradableForTokenList(address[] calldata _tokens, bool[] calldata _tradable) external {
-        for (uint16 i = 0; i < _tokens.length; i++) {
+        require(_tokens.length == _tradable.length, "TPS: Array length mismatch");
+        for (uint256 i = 0; i < _tokens.length; i++) {
             require(msg.sender == owner || (!_tradable[i] && managers[msg.sender]), "TPS: Unauthorised");
             tokenInfo[_tokens[i]].isTradable = _tradable[i];
         }

--- a/contracts/infrastructure/storage/TokenPriceStorage.sol
+++ b/contracts/infrastructure/storage/TokenPriceStorage.sol
@@ -28,27 +28,56 @@ import "../base/Managed.sol";
  * Only managers of this contract can modify its state.
  */
 contract TokenPriceStorage is ITokenPriceStorage, Storage, Managed {
-    mapping(address => uint256) public cachedPrices;
-
-    function getTokenPrice(address _token) external override view returns (uint256 _price) {
-        _price = cachedPrices[_token];
+    struct TokenInfo {
+        uint184 cachedPrice;
+        uint64 updatedAt;
+        bool isTradable;
     }
 
-    function getPriceForTokenList(address[] calldata _tokens) external override view returns (uint256[] memory) {
-        uint256[] memory prices = new uint256[](_tokens.length);
+    // Price info per token
+    mapping(address => TokenInfo) public tokenInfo;
+    // The minimum period between two price updates
+    uint256 public minPriceUpdatePeriod;
+
+
+    // Getters
+
+    function getTokenPrice(address _token) external override view returns (uint184 _price) {
+        _price = tokenInfo[_token].cachedPrice;
+    }
+    function isTokenTradable(address _token) external override view returns (bool _isTradable) {
+        _isTradable = tokenInfo[_token].isTradable;
+    }
+    function getPriceForTokenList(address[] calldata _tokens) external view returns (uint184[] memory _prices) {
+        _prices = new uint184[](_tokens.length);
         for (uint i = 0; i < _tokens.length; i++) {
-            prices[i] = cachedPrices[_tokens[i]];
+            _prices[i] = tokenInfo[_tokens[i]].cachedPrice;
         }
-        return prices;
+    }
+    function getTradableForTokenList(address[] calldata _tokens) external view returns (bool[] memory _tradable) {
+        _tradable = new bool[](_tokens.length);
+        for (uint i = 0; i < _tokens.length; i++) {
+            _tradable[i] = tokenInfo[_tokens[i]].isTradable;
+        }
     }
 
-    function setPriceForTokenList(address[] calldata _tokens, uint256[] calldata _prices) external override onlyManager {
+    // Setters
+    
+    function setMinPriceUpdatePeriod(uint256 _newPeriod) external onlyOwner {
+        minPriceUpdatePeriod = _newPeriod;
+    }
+    function setPriceForTokenList(address[] calldata _tokens, uint184[] calldata _prices) external onlyManager {
         for (uint16 i = 0; i < _tokens.length; i++) {
-            cachedPrices[_tokens[i]] = _prices[i];
+            uint64 updatedAt = tokenInfo[_tokens[i]].updatedAt;
+            require(updatedAt == 0 || block.timestamp >= updatedAt + minPriceUpdatePeriod, "TPS: Price updated too early");
+            tokenInfo[_tokens[i]].cachedPrice = _prices[i];
+            tokenInfo[_tokens[i]].updatedAt = uint64(block.timestamp);
         }
     }
-
-    function setPrice(address _token, uint256 _price) external override onlyManager {
-        cachedPrices[_token] = _price;
+    function setTradableForTokenList(address[] calldata _tokens, bool[] calldata _tradable) external {
+        for (uint16 i = 0; i < _tokens.length; i++) {
+            require(msg.sender == owner || (!_tradable[i] && managers[msg.sender]), "TPS: Unauthorised");
+            tokenInfo[_tokens[i]].isTradable = _tradable[i];
+        }
     }
 }

--- a/contracts/modules/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer.sol
@@ -171,7 +171,9 @@ contract ApprovedTransfer is BaseTransfer {
      */
     function getRequiredSignatures(address _wallet, bytes calldata _data) external view override returns (uint256, OwnerSignature) {
         // owner  + [n/2] guardians
-        uint numberOfSignatures = 1 + Utils.ceil(guardianStorage.guardianCount(_wallet), 2);
+        uint numberOfGuardians = Utils.ceil(guardianStorage.guardianCount(_wallet), 2);
+        require(numberOfGuardians > 0, "AT: no guardians set on wallet");
+        uint numberOfSignatures = 1 + numberOfGuardians;
         return (numberOfSignatures, OwnerSignature.Required);
     }
 }

--- a/contracts/modules/RecoveryManager.sol
+++ b/contracts/modules/RecoveryManager.sol
@@ -146,8 +146,7 @@ contract RecoveryManager is BaseModule {
     }
 
     /**
-     * @notice Lets the owner start the execution of the ownership transfer procedure.
-     * Once triggered the ownership transfer is pending for the security period before it can be finalised.
+     * @notice Lets the owner transfer the wallet ownership. This is executed immediately.
      * @param _wallet The target wallet.
      * @param _newOwner The address to which ownership should be transferred.
      */

--- a/contracts/modules/RelayerModule.sol
+++ b/contracts/modules/RelayerModule.sol
@@ -276,7 +276,7 @@ contract RelayerModule is BaseModule {
         }
         bool isGuardian;
 
-        for (uint8 i = 0; i < _signatures.length / 65; i++) {
+        for (uint256 i = 0; i < _signatures.length / 65; i++) {
             address signer = Utils.recoverSigner(_signHash, _signatures, i);
 
             if (i == 0) {

--- a/contracts/modules/RelayerModule.sol
+++ b/contracts/modules/RelayerModule.sol
@@ -197,6 +197,7 @@ contract RelayerModule is BaseModule {
                     _to,
                     _value,
                     _data,
+                    getChainId(),
                     _nonce,
                     _gasPrice,
                     _gasLimit,
@@ -361,5 +362,14 @@ contract RelayerModule is BaseModule {
         require(_data.length >= 36, "RM: Invalid dataWallet");
         address dataWallet = abi.decode(_data[4:], (address));
         return dataWallet == _wallet;
+    }
+
+   /**
+    * @notice Returns the current chainId
+    * @return chainId the chainId
+    */
+    function getChainId() private pure returns (uint256 chainId) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly { chainId := chainid() }
     }
 }

--- a/contracts/modules/RelayerModule.sol
+++ b/contracts/modules/RelayerModule.sol
@@ -348,7 +348,11 @@ contract RelayerModule is BaseModule {
             invokeWallet(_wallet, refundAddress, refundAmount, EMPTY_BYTES);
         } else {
             bytes memory methodData = abi.encodeWithSignature("transfer(address,uint256)", refundAddress, refundAmount);
-		    invokeWallet(_wallet, _refundToken, 0, methodData);
+		    bytes memory transferSuccessBytes = invokeWallet(_wallet, _refundToken, 0, methodData);
+            // Check token refund is successful, when `transfer` returns a success bool result
+            if (transferSuccessBytes.length > 0) {
+                require(abi.decode(transferSuccessBytes, (bool)), "RM: Refund transfer failed");
+            }
         }
         emit Refund(_wallet, refundAddress, _refundToken, refundAmount);
     }

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -342,7 +342,6 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
         onlyWalletOwnerOrModule(_wallet)
         onlyWhenUnlocked(_wallet)
     {
-        require(isWhitelisted(_wallet, _target), "TT: target not whitelisted");
         transferStorage.setWhitelist(_wallet, _target, 0);
         emit RemovedFromWhitelist(_wallet, _target);
     }

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -543,7 +543,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     }
 
     /**
-    * @notice Make sure a contract call is not trying to call a module, the wallet itself, or a supported ERC20.
+    * @notice Make sure a contract call is not trying to call a supported ERC20.
     * @param _wallet The target wallet.
     * @param _contract The address of the contract.
      */

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -74,6 +74,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     address token, address to, uint256 amount, bytes data);
     event PendingTransferExecuted(address indexed wallet, bytes32 indexed id);
     event PendingTransferCanceled(address indexed wallet, bytes32 indexed id);
+    event DailyLimitMigrated(address indexed wallet, uint256 currentDailyLimit, uint256 pendingDailyLimit, uint256 changeDailyLimitAfter);
 
     // *************** Constructor ********************** //
 
@@ -135,6 +136,8 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
                         ILimitStorage.DailySpent(LimitUtils.safe128(current.sub(unspent)), periodEnd)
                     );
                 }
+
+                emit DailyLimitMigrated(_wallet, current, pending, changeAfter);
             }
         }
     }

--- a/contracts/modules/TransferManager.sol
+++ b/contracts/modules/TransferManager.sol
@@ -75,6 +75,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
     event PendingTransferExecuted(address indexed wallet, bytes32 indexed id);
     event PendingTransferCanceled(address indexed wallet, bytes32 indexed id);
     event DailyLimitMigrated(address indexed wallet, uint256 currentDailyLimit, uint256 pendingDailyLimit, uint256 changeDailyLimitAfter);
+    event DailyLimitDisabled(address indexed wallet, uint256 securityPeriod);
 
     // *************** Constructor ********************** //
 
@@ -412,6 +413,7 @@ contract TransferManager is OnlyOwnerModule, BaseTransfer {
      */
     function disableLimit(address _wallet) external onlyWalletOwnerOrModule(_wallet) onlyWhenUnlocked(_wallet) {
         LimitUtils.disableLimit(limitStorage, _wallet, securityPeriod);
+        emit DailyLimitDisabled(_wallet, securityPeriod);
     }
 
     /**

--- a/contracts/modules/common/BaseTransfer.sol
+++ b/contracts/modules/common/BaseTransfer.sol
@@ -77,7 +77,11 @@ abstract contract BaseTransfer is BaseModule {
             invokeWallet(_wallet, _to, _value, EMPTY_BYTES);
         } else {
             bytes memory methodData = abi.encodeWithSignature("transfer(address,uint256)", _to, _value);
-            invokeWallet(_wallet, _token, 0, methodData);
+            bytes memory transferSuccessBytes = invokeWallet(_wallet, _token, 0, methodData);
+            // Check transfer is successful, when `transfer` returns a success bool result
+            if (transferSuccessBytes.length > 0) {
+                require(abi.decode(transferSuccessBytes, (bool)), "RM: Transfer failed");
+            }
         }
         emit Transfer(_wallet, _token, _value, _to, _data);
     }

--- a/contracts/modules/common/BaseTransfer.sol
+++ b/contracts/modules/common/BaseTransfer.sol
@@ -116,7 +116,7 @@ abstract contract BaseTransfer is BaseModule {
     * The address that spends the _token and the address that is called with _data can be different.
     * @param _wallet The target wallet.
     * @param _token The ERC20 address.
-    * @param _spender The spender address.
+    * @param _proxy The address to approve.
     * @param _amount The amount of tokens to transfer.
     * @param _contract The contract address.
     * @param _data The method data.
@@ -124,7 +124,7 @@ abstract contract BaseTransfer is BaseModule {
     function doApproveTokenAndCallContract(
         address _wallet,
         address _token,
-        address _spender,
+        address _proxy,
         uint256 _amount,
         address _contract,
         bytes memory _data
@@ -135,31 +135,31 @@ abstract contract BaseTransfer is BaseModule {
         uint256 balance = ERC20(_token).balanceOf(_wallet);
         require(balance >= _amount, "BT: insufficient balance");
 
-        uint256 existingAllowance = ERC20(_token).allowance(_wallet, _spender);
+        uint256 existingAllowance = ERC20(_token).allowance(_wallet, _proxy);
         uint256 totalAllowance = SafeMath.add(existingAllowance, _amount);
         // Approve the desired amount plus existing amount. This logic allows for potential gas saving later
-        // when restoring the original approved amount, in cases where the _spender uses the exact approved _amount.
-        bytes memory methodData = abi.encodeWithSignature("approve(address,uint256)", _spender, totalAllowance);
+        // when restoring the original approved amount, in cases where the _proxy uses the exact approved _amount.
+        bytes memory methodData = abi.encodeWithSignature("approve(address,uint256)", _proxy, totalAllowance);
 
         invokeWallet(_wallet, _token, 0, methodData);
         invokeWallet(_wallet, _contract, 0, _data);
 
         // Calculate the approved amount that was spent after the call
-        uint256 unusedAllowance = ERC20(_token).allowance(_wallet, _spender);
+        uint256 unusedAllowance = ERC20(_token).allowance(_wallet, _proxy);
         uint256 usedAllowance = SafeMath.sub(totalAllowance, unusedAllowance);
         // Ensure the amount spent does not exceed the amount approved for this call
         require(usedAllowance <= _amount, "BT: insufficient amount for call");
 
         if (unusedAllowance != existingAllowance) {
             // Restore the original allowance amount if the amount spent was different (can be lower).
-            methodData = abi.encodeWithSignature("approve(address,uint256)", _spender, existingAllowance);
+            methodData = abi.encodeWithSignature("approve(address,uint256)", _proxy, existingAllowance);
             invokeWallet(_wallet, _token, 0, methodData);
         }
 
         emit ApprovedAndCalledContract(
             _wallet,
             _contract,
-            _spender,
+            _proxy,
             _token,
             _amount,
             usedAllowance,
@@ -170,14 +170,14 @@ abstract contract BaseTransfer is BaseModule {
     * @notice Helper method to wrap ETH into WETH, approve a certain amount of WETH and call an external contract.
     * The address that spends the WETH and the address that is called with _data can be different.
     * @param _wallet The target wallet.
-    * @param _spender The spender address.
+    * @param _proxy The address to approves.
     * @param _amount The amount of tokens to transfer.
     * @param _contract The contract address.
     * @param _data The method data.
     */
     function doApproveWethAndCallContract(
         address _wallet,
-        address _spender,
+        address _proxy,
         uint256 _amount,
         address _contract,
         bytes memory _data
@@ -190,6 +190,6 @@ abstract contract BaseTransfer is BaseModule {
             invokeWallet(_wallet, wethToken, _amount - wethBalance, abi.encodeWithSignature("deposit()"));
         }
 
-        doApproveTokenAndCallContract(_wallet, wethToken, _spender, _amount, _contract, _data);
+        doApproveTokenAndCallContract(_wallet, wethToken, _proxy, _amount, _contract, _data);
     }
 }

--- a/contracts/modules/common/Utils.sol
+++ b/contracts/modules/common/Utils.sol
@@ -42,7 +42,10 @@ library Utils {
             v := and(mload(add(_signatures, add(0x41,mul(0x41,_index)))), 0xff)
         }
         require(v == 27 || v == 28);
-        return ecrecover(_signedHash, v, r, s);
+
+        address recoveredAddress = ecrecover(_signedHash, v, r, s);
+        require(recoveredAddress != address(0), "Utils: ecrecover returned 0");
+        return recoveredAddress;
     }
 
     /**

--- a/contracts/modules/maker/MakerV2Loan.sol
+++ b/contracts/modules/maker/MakerV2Loan.sol
@@ -630,8 +630,6 @@ abstract contract MakerV2Loan is MakerV2Base {
         internal
     {
         verifyValidRepayment(_cdpId, _amount);
-        // Convert some ETH into DAI with Uniswap if necessary
-        buyTokens(_wallet, daiToken, _amount, daiUniswap);
         // Move the DAI from the wallet to the vat.
         joinDebt(_wallet, _cdpId, _amount);
         // Get the accumulated rate for the collateral type

--- a/contracts/modules/maker/MakerV2Loan.sol
+++ b/contracts/modules/maker/MakerV2Loan.sol
@@ -68,6 +68,7 @@ abstract contract MakerV2Loan is MakerV2Base {
         address _debtToken,
         uint256 _debtAmount
     );
+    event LoanAcquired(address indexed _wallet, bytes32 indexed _loanId);
     event LoanClosed(address indexed _wallet, bytes32 indexed _loanId);
     event CollateralAdded(address indexed _wallet, bytes32 indexed _loanId, address _collateral, uint256 _collateralAmount);
     event CollateralRemoved(address indexed _wallet, bytes32 indexed _loanId, address _collateral, uint256 _collateralAmount);
@@ -282,6 +283,7 @@ abstract contract MakerV2Loan is MakerV2Base {
         require(cdpManager.owns(uint256(_loanId)) == address(this), "MV2: failed give");
         // Mark the incoming vault as belonging to the wallet (or merge it into the existing vault if there is one)
         assignLoanToWallet(_wallet, _loanId);
+        emit LoanAcquired(_wallet, _loanId);
     }
 
     /**

--- a/contracts/modules/maker/MakerV2Loan.sol
+++ b/contracts/modules/maker/MakerV2Loan.sol
@@ -59,8 +59,6 @@ abstract contract MakerV2Loan is MakerV2Base {
 
     // ****************** Events *************************** //
 
-    // Emitted when an SCD CDP is converted into an MCD vault
-    event CdpMigrated(address indexed _wallet, bytes32 _oldCdpId, bytes32 _newVaultId);
     // Vault management events
     event LoanOpened(
         address indexed _wallet,
@@ -287,42 +285,6 @@ abstract contract MakerV2Loan is MakerV2Base {
     }
 
     /**
-     * @notice Lets a SCD CDP owner migrate their CDP to use the new MCD engine.
-     * Requires MKR or ETH to pay the SCD governance fee
-     * @param _wallet The target wallet.
-     * @param _cup id of the old SCD CDP to migrate
-     */
-    function migrateCdp(
-        address _wallet,
-        bytes32 _cup
-    )
-        external
-        onlyWalletOwnerOrModule(_wallet)
-        onlyWhenUnlocked(_wallet)
-        returns (bytes32 _loanId)
-    {
-        (uint daiPerMkr, bool ok) = tub.pep().peek();
-        if (ok && daiPerMkr != 0) {
-            // get governance fee in MKR
-            uint mkrFee = wdiv(tub.rap(_cup), daiPerMkr);
-            // Convert some ETH into MKR with Uniswap if necessary
-            buyTokens(_wallet, mkrToken, mkrFee, mkrUniswap);
-            // Transfer the MKR to the Migration contract
-            invokeWallet(_wallet, address(mkrToken), 0, abi.encodeWithSignature("transfer(address,uint256)", address(scdMcdMigration), mkrFee));
-        }
-        // Transfer ownership of the SCD CDP to the migration contract
-        invokeWallet(_wallet, address(tub), 0, abi.encodeWithSignature("give(bytes32,address)", _cup, address(scdMcdMigration)));
-        // Update stability fee rate
-        jug.drip(wethJoin.ilk());
-        // Execute the CDP migration
-        _loanId = bytes32(ScdMcdMigrationLike(scdMcdMigration).migrate(_cup));
-        // Mark the new vault as belonging to the wallet (or merge it into the existing vault if there is one)
-        _loanId = assignLoanToWallet(_wallet, _loanId);
-
-        emit CdpMigrated(_wallet, _cup, _loanId);
-    }
-
-    /**
      * @notice Lets a future upgrade of this module transfer a vault to itself
      * @param _wallet The target wallet.
      * @param _loanId The ID of the target vault.
@@ -374,28 +336,6 @@ abstract contract MakerV2Loan is MakerV2Base {
         if (_collateral != ETH_TOKEN) {
             (bool collateralSupported,,,) = makerRegistry.collaterals(_collateral);
             require(collateralSupported, "MV2: unsupported collateral");
-        }
-    }
-
-    function buyTokens(
-        address _wallet,
-        GemLike _token,
-        uint256 _tokenAmountRequired,
-        IUniswapExchange _uniswapExchange
-    )
-        internal
-    {
-        // get token balance
-        uint256 tokenBalance = _token.balanceOf(_wallet);
-        if (tokenBalance < _tokenAmountRequired) {
-            // Not enough tokens => Convert some ETH into tokens with Uniswap
-            uint256 etherValueOfTokens = _uniswapExchange.getEthToTokenOutputPrice(_tokenAmountRequired - tokenBalance);
-            invokeWallet(
-                _wallet,
-                address(_uniswapExchange),
-                etherValueOfTokens,
-                abi.encodeWithSignature("ethToTokenSwapOutput(uint256,uint256)", _tokenAmountRequired - tokenBalance, block.timestamp)
-            );
         }
     }
 

--- a/deployment/7_upgrade_2_0.js
+++ b/deployment/7_upgrade_2_0.js
@@ -134,6 +134,7 @@ const deploy = async (network) => {
     {},
     config.contracts.ModuleRegistry,
     config.modules.GuardianStorage,
+    TokenPriceStorageWrapper.contractAddress,
     config.CryptoKitties.contract,
   );
   newModuleWrappers.push(NftTransferWrapper);

--- a/deployment/7_upgrade_2_0.js
+++ b/deployment/7_upgrade_2_0.js
@@ -153,6 +153,7 @@ const deploy = async (network) => {
     {},
     config.contracts.ModuleRegistry,
     config.modules.GuardianStorage,
+    TokenPriceStorageWrapper.contractAddress,
     config.defi.paraswap.contract,
     "argent",
     Object.values(config.defi.paraswap.authorisedExchanges),

--- a/deployment/7_upgrade_2_0.js
+++ b/deployment/7_upgrade_2_0.js
@@ -26,7 +26,7 @@ const ENSManager = require("../build/ArgentENSManager");
 
 const utils = require("../utils/utilities.js");
 
-const TARGET_VERSION = "2.0.1";
+const TARGET_VERSION = "2.0.0";
 const MODULES_TO_ENABLE = [
   "ApprovedTransfer",
   "CompoundManager",
@@ -41,7 +41,7 @@ const MODULES_TO_ENABLE = [
 ];
 const MODULES_TO_DISABLE = ["MakerManager"];
 
-const BACKWARD_COMPATIBILITY = 1;
+const BACKWARD_COMPATIBILITY = 3;
 
 const deploy = async (network) => {
   if (!["kovan", "kovan-fork", "staging", "prod"].includes(network)) {

--- a/deployment/999_benchmark.js
+++ b/deployment/999_benchmark.js
@@ -216,7 +216,7 @@ class Benchmark {
   }
 
   async estimateAddGuardianRelayed() {
-    const gasUsed = await this.relayEstimate(
+    const gasUsed = await this.relay(
       this.GuardianManagerWrapper,
       "addGuardian",
       [this.walletAddress, this.accounts[1]],
@@ -232,7 +232,7 @@ class Benchmark {
       [this.walletAddress, this.accounts[1]], this.wallet, [this.signers[0]]);
 
     // estimate revoke guardian
-    const gasUsed = await this.relayEstimate(
+    const gasUsed = await this.relay(
       this.GuardianManagerWrapper,
       "revokeGuardian",
       [this.walletAddress, this.accounts[1]],
@@ -270,7 +270,7 @@ class Benchmark {
     await this.GuardianManagerWrapper.addGuardian(this.walletAddress, this.accounts[1]);
 
     // estimate lock wallet
-    const gasUsed = await this.relayEstimate(
+    const gasUsed = await this.relay(
       this.LockManagerWrapper,
       "lock",
       [this.walletAddress],
@@ -288,7 +288,7 @@ class Benchmark {
     await this.relay(this.LockManagerWrapper, "lock", [this.walletAddress], this.wallet, [this.signers[1]]);
 
     // estimate unlock wallet
-    const gasUsed = await this.relayEstimate(this.LockManagerWrapper, "unlock",
+    const gasUsed = await this.relay(this.LockManagerWrapper, "unlock",
       [this.walletAddress], this.wallet, [this.signers[1]]);
     this._logger.addItem("Unlock wallet (relayed)", gasUsed);
   }
@@ -303,7 +303,7 @@ class Benchmark {
     // estimate execute recovery
     const recoveryAddress = this.accounts[3];
     const signers = [this.signers[1], this.signers[2]];
-    const gasUsed = await this.relayEstimate(this.RecoveryManagerWrapper, "executeRecovery",
+    const gasUsed = await this.relay(this.RecoveryManagerWrapper, "executeRecovery",
       [this.walletAddress, recoveryAddress], this.wallet, [signers[1]]);
     this._logger.addItem("Execute recovery", gasUsed);
   }
@@ -314,7 +314,7 @@ class Benchmark {
   }
 
   async estimateChangeLimitRelayed() {
-    const gasUsed = await this.relayEstimate(this.TransferManagerWrapper, "changeLimit",
+    const gasUsed = await this.relay(this.TransferManagerWrapper, "changeLimit",
       [this.walletAddress, 67000000], this.wallet, [this.signers[0]]);
     this._logger.addItem("Change limit (relayed)", gasUsed);
   }
@@ -337,7 +337,7 @@ class Benchmark {
     await this.testManager.increaseTime(this.config.settings.securityPeriod + 1);
 
     // transfer
-    const gasUsed = await this.relayEstimate(
+    const gasUsed = await this.relay(
       this.TransferManagerWrapper,
       "transferToken",
       [this.walletAddress, ETH_TOKEN, this.accounts[1], 1000000, "0x"],
@@ -355,7 +355,7 @@ class Benchmark {
   }
 
   async estimateSmallTransferRelayed() {
-    const gasUsed = await this.relayEstimate(
+    const gasUsed = await this.relay(
       this.TransferManagerWrapper,
       "transferToken",
       [this.walletAddress, ETH_TOKEN, this.accounts[1], 1000, "0x"],
@@ -379,7 +379,7 @@ class Benchmark {
     await this.TransferManagerWrapper.addToWhitelist(this.walletAddress, this.accounts[3]);
     await this.testManager.increaseTime(this.config.settings.securityPeriod + 1);
 
-    const gasUsed = await this.relayEstimate(
+    const gasUsed = await this.relay(
       this.TransferManagerWrapper,
       "transferToken",
       [this.walletAddress, ETH_TOKEN, this.accounts[3], 2000000, "0x"],
@@ -412,7 +412,7 @@ class Benchmark {
     await this.GuardianManagerWrapper.addGuardian(this.walletAddress, this.accounts[1]);
 
     // estimate approve large transfer
-    const gasUsed = await this.relayEstimate(
+    const gasUsed = await this.relay(
       this.ApprovedTransferWrapper,
       "transferToken",
       [this.walletAddress, ETH_TOKEN, this.accounts[3], 2000000, "0x"],
@@ -435,7 +435,7 @@ class Benchmark {
 
     // estimate approve large transfer
     const signers = [this.signers[0], this.signers[1], this.signers[2]];
-    const gasUsed = await this.relayEstimate(
+    const gasUsed = await this.relay(
       this.ApprovedTransferWrapper,
       "transferToken",
       [this.walletAddress, ETH_TOKEN, this.accounts[5], 2000000, "0x"],
@@ -449,14 +449,9 @@ class Benchmark {
   // //// utils ////////
   // ///////////////////
 
-  async relay(target, method, params, wallet, signers, estimate = false) {
-    const result = await this.testManager.relay(target, method, params, wallet, signers, this.accounts[9], estimate);
-    return result;
-  }
-
-  async relayEstimate(target, method, params, wallet, signers) {
-    const result = await this.relay(target, method, params, wallet, signers, true);
-    return result;
+  async relay(target, method, params, wallet, signers) {
+    const txReceipt = await this.testManager.relay(target, method, params, wallet, signers, this.accounts[9], false);
+    return txReceipt.gasUsed.toString();
   }
 
   getAllEstimateMethods() {

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -148,6 +148,10 @@ describe("Approved Transfer", function () {
       );
     }
 
+    it("should fail to transfer ETH on a wallet with no guardian", async () => {
+      await expectFailingTransferToken(ETH_TOKEN, [owner], "AT: no guardians set on wallet");
+    });
+
     describe("Approved by EOA guardians", () => {
       describe("1 guardian", () => {
         beforeEach(async () => {
@@ -246,6 +250,22 @@ describe("Approved Transfer", function () {
   });
 
   describe("Contract call", () => {
+    it("should fail to call contract on a wallet with no guardian", async () => {
+      contract = await deployer.deploy(TestContract);
+      const dataToTransfer = contract.contract.interface.functions.setState.encode([1]);
+
+      await assert.revertWith(
+        manager.relay(
+          approvedTransfer,
+          "callContract",
+          [wallet.contractAddress, contract.contractAddress, amountToTransfer, dataToTransfer],
+          wallet,
+          [owner],
+        ),
+        "AT: no guardians set on wallet",
+      );
+    });
+
     describe("Approved by 1 EOA and 2 smart-contract guardians", () => {
       beforeEach(async () => {
         contract = await deployer.deploy(TestContract);

--- a/test/makerV2Manager_loan.js
+++ b/test/makerV2Manager_loan.js
@@ -5,7 +5,7 @@ const {
 } = require("../utils/defi-deployer");
 
 const { parseEther, formatBytes32String } = ethers.utils;
-const { HashZero, AddressZero } = ethers.constants;
+const { AddressZero } = ethers.constants;
 
 const TestManager = require("../utils/test-manager");
 const GemJoin = require("../build/GemJoin");
@@ -137,6 +137,7 @@ describe("MakerV2 Vaults", function () {
       ]);
     walletAddress = wallet.contractAddress;
     await infrastructure.sendTransaction({ to: walletAddress, value: parseEther("2.0") });
+    await dai["mint(address,uint256)"](walletAddress, parseEther("10"));
   });
 
   async function getTestAmounts(tokenAddress) {
@@ -405,17 +406,11 @@ describe("MakerV2 Vaults", function () {
     });
   });
 
-  async function testRepayDebt({ useDai, relayed }) {
+  async function testRepayDebt({ relayed }) {
     const { collateralAmount, daiAmount: daiAmount_ } = await getTestAmounts(ETH_TOKEN);
     const daiAmount = daiAmount_.add(parseEther("0.3"));
 
     const loanId = await testOpenLoan({ collateralAmount, daiAmount, relayed });
-    if (!useDai) {
-      // move the borrowed DAI from the wallet to the owner
-      await transferManager.from(owner).transferToken(walletAddress, dai.contractAddress, owner.address, daiAmount, HashZero, { gasLimit: 3000000 });
-      // give some ETH to the wallet to be used for repayment
-      await owner.sendTransaction({ to: walletAddress, value: collateralAmount });
-    }
     await manager.increaseTime(3); // wait 3 seconds
     const beforeDAI = await dai.balanceOf(wallet.contractAddress);
     const beforeETH = await deployer.provider.getBalance(wallet.contractAddress);
@@ -426,25 +421,16 @@ describe("MakerV2 Vaults", function () {
     const afterDAI = await dai.balanceOf(wallet.contractAddress);
     const afterETH = await deployer.provider.getBalance(wallet.contractAddress);
 
-    if (useDai) assert.isTrue(afterDAI.lt(beforeDAI) && afterETH.eq(beforeETH), "should have less DAI");
-    else assert.isTrue(afterDAI.eq(beforeDAI) && afterETH.lt(beforeETH), "should have less ETH");
+    assert.isTrue(afterDAI.lt(beforeDAI) && afterETH.eq(beforeETH), "should have less DAI");
   }
 
   describe("Repay Debt", () => {
-    it("should repay debt when paying fee in DAI (blockchain tx)", async () => {
-      await testRepayDebt({ useDai: true, relayed: false });
+    it("should repay debt (blockchain tx)", async () => {
+      await testRepayDebt({ relayed: false });
     });
 
-    it("should repay debt when paying fee in DAI (relayed tx)", async () => {
-      await testRepayDebt({ useDai: true, relayed: true });
-    });
-
-    it("should repay debt when paying fee in ETH (blockchain tx)", async () => {
-      await testRepayDebt({ useDai: false, relayed: false });
-    });
-
-    it("should repay debt when paying fee in ETH (relayed tx)", async () => {
-      await testRepayDebt({ useDai: false, relayed: true });
+    it("should repay debt (relayed tx)", async () => {
+      await testRepayDebt({ relayed: true });
     });
 
     it("should not repay debt when only dust left", async () => {
@@ -470,18 +456,14 @@ describe("MakerV2 Vaults", function () {
     });
   });
 
-  async function testCloseLoan({ useDai, relayed }) {
+  async function testCloseLoan({ relayed }) {
     const { collateralAmount, daiAmount } = await getTestAmounts(ETH_TOKEN);
     const loanId = await testOpenLoan({ collateralAmount, daiAmount, relayed });
     // give some ETH to the wallet to be used for repayment
     await owner.sendTransaction({ to: walletAddress, value: collateralAmount.mul(2) });
-    if (!useDai) {
-      // move the borrowed DAI from the wallet to the owner
-      await transferManager.from(owner).transferToken(walletAddress, dai.contractAddress, owner.address, daiAmount, HashZero, { gasLimit: 3000000 });
-    }
+
     await manager.increaseTime(3); // wait 3 seconds
     const beforeDAI = await dai.balanceOf(wallet.contractAddress);
-    const beforeETH = await deployer.provider.getBalance(wallet.contractAddress);
     const method = "closeLoan";
     const params = [wallet.contractAddress, loanId];
     if (relayed) {
@@ -491,27 +473,17 @@ describe("MakerV2 Vaults", function () {
       await makerV2.from(owner)[method](...params, { gasLimit: 3000000 });
     }
     const afterDAI = await dai.balanceOf(wallet.contractAddress);
-    const afterETH = await deployer.provider.getBalance(wallet.contractAddress);
 
-    if (useDai) assert.isTrue(afterDAI.lt(beforeDAI) && afterETH.sub(collateralAmount).lt(beforeETH), "should have spent some DAI and some ETH");
-    else assert.isTrue(afterDAI.eq(beforeDAI) && afterETH.sub(collateralAmount).lt(beforeETH), "should have spent some ETH");
+    assert.isTrue(afterDAI.lt(beforeDAI), "should have spent some DAI");
   }
 
   describe("Close Vaults", () => {
-    it("should close a vault when paying fee in DAI + ETH (blockchain tx)", async () => {
-      await testCloseLoan({ useDai: true, relayed: false });
+    it("should close a vault (blockchain tx)", async () => {
+      await testCloseLoan({ relayed: false });
     });
 
-    it("should close a vault when paying fee in DAI + ETH (relayed tx)", async () => {
-      await testCloseLoan({ useDai: true, relayed: true });
-    });
-
-    it("should close a vault when paying fee in ETH (blockchain tx)", async () => {
-      await testCloseLoan({ useDai: false, relayed: false });
-    });
-
-    it("should close a vault when paying fee in ETH (relayed tx)", async () => {
-      await testCloseLoan({ useDai: false, relayed: true });
+    it("should close a vault (relayed tx)", async () => {
+      await testCloseLoan({ relayed: true });
     });
 
     it("should not close a vault for the wrong loan owner", async () => {

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -430,6 +430,7 @@ describe("RecoveryManager", function () {
 
       it("should revert if an unknown method is executed", async () => {
         const nonce = await manager.getNonceForRelay();
+        const chainId = await manager.getChainId();
         let methodData = recoveryManager.contract.interface.functions.executeRecovery.encode([wallet.contractAddress, ethers.constants.AddressZero]);
         // Replace the `executeRecovery` method signature: b0ba4da0 with a non-existent one: e0b6fcfc
         methodData = methodData.replace("b0ba4da0", "e0b6fcfc");
@@ -440,6 +441,7 @@ describe("RecoveryManager", function () {
           recoveryManager.contractAddress,
           0,
           methodData,
+          chainId,
           nonce,
           0,
           700000,

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -361,9 +361,10 @@ describe("RelayerModule", function () {
     });
 
     it("should fail when relayed on non-OnlyOwnerModule modules", async () => {
+      await guardianManager.from(owner).addGuardian(wallet.contractAddress, guardian.address);
       await registry.registerModule(testModuleNew.contractAddress, formatBytes32String("testModuleNew"));
       const params = [wallet.contractAddress, testModuleNew.contractAddress];
-      const txReceipt = await manager.relay(approvedTransfer, "addModule", params, wallet, [owner]);
+      const txReceipt = await manager.relay(approvedTransfer, "addModule", params, wallet, [owner, guardian]);
       const { success, error } = parseRelayReceipt(txReceipt);
       assert.isFalse(success);
       assert.equal(error, "BM: must be wallet owner");

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -207,7 +207,7 @@ describe("RelayerModule", function () {
       const decimals = 12; // number of decimal for TOKN contract
       const tokenRate = new BN(10).pow(new BN(19)).muln(51); // 1 TOKN = 0.00051 ETH = 0.00051*10^18 ETH wei => *10^(18-decimals) = 0.00051*10^18 * 10^6 = 0.00051*10^24 = 51*10^19
       erc20 = await deployer.deploy(ERC20, {}, [infrastructure.address], 10000000, decimals); // TOKN contract with 10M tokens (10M TOKN for account[0])
-      await tokenPriceStorage.setPrice(erc20.contractAddress, tokenRate.toString());
+      await tokenPriceStorage.setPriceForTokenList([erc20.contractAddress], [tokenRate.toString()]);
       await limitModule.setLimitAndDailySpent(wallet.contractAddress, 10000000000, 0);
     });
 

--- a/test/tokenPriceStorage.js
+++ b/test/tokenPriceStorage.js
@@ -1,0 +1,73 @@
+/* global accounts */
+
+const TokenPriceStorage = require("../build/TokenPriceStorage");
+const ERC20 = require("../build/TestERC20");
+const TestManager = require("../utils/test-manager");
+
+describe("TokenPriceStorage", function () {
+  this.timeout(100000);
+  const testManager = new TestManager();
+  const deployer = testManager.newDeployer();
+  const owner = accounts[0].signer;
+  const manager = accounts[1].signer;
+
+  let tokenAddress;
+  let tokenPriceStorage;
+
+  before(async () => {
+    tokenAddress = (await (await deployer.deploy(ERC20, {}, [], 1, 18)).contractAddress);
+  });
+
+  beforeEach(async () => {
+    tokenPriceStorage = await deployer.deploy(TokenPriceStorage);
+    await tokenPriceStorage.addManager(manager.address);
+    await tokenPriceStorage.setMinPriceUpdatePeriod(3600);
+  });
+
+  describe("Price changes", () => {
+    it("lets managers change price after security period", async () => {
+      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [111111]);
+      const beforePrice = await tokenPriceStorage.getTokenPrice(tokenAddress);
+      assert.equal(beforePrice.toString(), "111111");
+      await testManager.increaseTime(3601);
+      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222]);
+      const afterPrice = await tokenPriceStorage.getTokenPrice(tokenAddress);
+      assert.equal(afterPrice.toString(), "222222");
+    });
+    it("does not let managers change price before security period", async () => {
+      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [111111]);
+      await testManager.increaseTime(3500);
+      await assert.revertWith(tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222]), "TPS: Price updated too early");
+    });
+    it("lets the owner change security period", async () => {
+      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [111111]);
+      await testManager.increaseTime(1600);
+      await assert.revertWith(tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222]), "TPS: Price updated too early");
+      await tokenPriceStorage.from(owner).setMinPriceUpdatePeriod(0);
+      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222]);
+      const afterPrice = await tokenPriceStorage.getTokenPrice(tokenAddress);
+      assert.equal(afterPrice.toString(), "222222");
+    });
+  });
+
+  describe("Tradable status changes", () => {
+    it("lets the owner change tradable status", async () => {
+      await tokenPriceStorage.from(owner).setTradableForTokenList([tokenAddress], [true]);
+      let tradable = await tokenPriceStorage.isTokenTradable(tokenAddress);
+      assert.isTrue(tradable);
+      await tokenPriceStorage.from(owner).setTradableForTokenList([tokenAddress], [false]);
+      tradable = await tokenPriceStorage.isTokenTradable(tokenAddress);
+      assert.isFalse(tradable);
+      await tokenPriceStorage.from(owner).setTradableForTokenList([tokenAddress], [true]);
+      tradable = await tokenPriceStorage.isTokenTradable(tokenAddress);
+      assert.isTrue(tradable);
+    });
+    it("lets managers set tradable to false only", async () => {
+      await tokenPriceStorage.from(owner).setTradableForTokenList([tokenAddress], [true]);
+      await tokenPriceStorage.from(manager).setTradableForTokenList([tokenAddress], [false]);
+      const tradable = await tokenPriceStorage.isTokenTradable(tokenAddress);
+      assert.isFalse(tradable);
+      await assert.revertWith(tokenPriceStorage.from(manager).setTradableForTokenList([tokenAddress], [true]), "TPS: Unauthorised");
+    });
+  });
+});

--- a/test/tokenPriceStorage.js
+++ b/test/tokenPriceStorage.js
@@ -34,6 +34,9 @@ describe("TokenPriceStorage", function () {
       const afterPrice = await tokenPriceStorage.getTokenPrice(tokenAddress);
       assert.equal(afterPrice.toString(), "222222");
     });
+    it("does not let managers change price with invalid array lengths", async () => {
+      await assert.revertWith(tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222, 333333]), "TPS: Array length mismatch");
+    });
     it("does not let managers change price before security period", async () => {
       await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [111111]);
       await testManager.increaseTime(3500);
@@ -68,6 +71,9 @@ describe("TokenPriceStorage", function () {
       const tradable = await tokenPriceStorage.isTokenTradable(tokenAddress);
       assert.isFalse(tradable);
       await assert.revertWith(tokenPriceStorage.from(manager).setTradableForTokenList([tokenAddress], [true]), "TPS: Unauthorised");
+    });
+    it("does not let managers change tradable with invalid array lengths", async () => {
+      await assert.revertWith(tokenPriceStorage.from(manager).setTradableForTokenList([tokenAddress], [false, false]), "TPS: Array length mismatch");
     });
   });
 });

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -115,7 +115,7 @@ describe("TransferManager", function () {
     const tokenRate = new BN(10).pow(new BN(19)).muln(51); // 1 TOKN = 0.00051 ETH = 0.00051*10^18 ETH wei => *10^(18-decimals) = 0.00051*10^18 * 10^6 = 0.00051*10^24 = 51*10^19
 
     erc20 = await deployer.deploy(ERC20, {}, [infrastructure.address, wallet.contractAddress], 10000000, decimals); // TOKN contract with 10M tokens (5M TOKN for wallet and 5M TOKN for account[0])
-    await tokenPriceStorage.setPrice(erc20.contractAddress, tokenRate.toString());
+    await tokenPriceStorage.setPriceForTokenList([erc20.contractAddress], [tokenRate.toString()]);
     await infrastructure.sendTransaction({ to: wallet.contractAddress, value: ethers.BigNumber.from("1000000000000000000") });
   });
 
@@ -194,7 +194,7 @@ describe("TransferManager", function () {
 
     it("should get a token price correctly", async () => {
       const tokenPrice = new BN(10).pow(new BN(18)).muln(1800);
-      await tokenPriceStorage.from(infrastructure).setPrice(erc20First.contractAddress, tokenPrice.toString());
+      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
       const tokenPriceSet = await tokenPriceStorage.getTokenPrice(erc20First.contractAddress);
       expect(tokenPrice).to.eq.BN(tokenPriceSet.toString());
     });
@@ -208,7 +208,7 @@ describe("TransferManager", function () {
 
     it("should set token price correctly", async () => {
       const tokenPrice = new BN(10).pow(new BN(18)).muln(1800);
-      await tokenPriceStorage.from(infrastructure).setPrice(erc20First.contractAddress, tokenPrice.toString());
+      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
       const tokenPriceSet = await tokenPriceStorage.cachedPrices(erc20First.contractAddress);
       expect(tokenPrice).to.eq.BN(tokenPriceSet.toString());
     });
@@ -223,7 +223,7 @@ describe("TransferManager", function () {
 
     it("should be able to get the ether value of a given amount of tokens", async () => {
       const tokenPrice = new BN(10).pow(new BN(18)).muln(1800);
-      await tokenPriceStorage.from(infrastructure).setPrice(erc20First.contractAddress, tokenPrice.toString());
+      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
       const etherValue = await getEtherValue("15000000000000000000", erc20First.contractAddress);
       // expectedValue = 1800*10^18/10^18 (price for 1 token wei) * 15*10^18 (amount) = 1800 * 15*10^18 = 27,000 * 10^18
       const expectedValue = new BN(10).pow(new BN(18)).muln(27000);
@@ -232,7 +232,7 @@ describe("TransferManager", function () {
 
     it("should be able to get the ether value for a token with 0 decimals", async () => {
       const tokenPrice = new BN(10).pow(new BN(36)).muln(23000);
-      await tokenPriceStorage.from(infrastructure).setPrice(erc20ZeroDecimals.contractAddress, tokenPrice.toString());
+      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20ZeroDecimals.contractAddress], [tokenPrice.toString()]);
       const etherValue = await getEtherValue(100, erc20ZeroDecimals.contractAddress);
       // expectedValue = 23000*10^36 * 100 / 10^18 = 2,300,000 * 10^18
       const expectedValue = new BN(10).pow(new BN(18)).muln(2300000);
@@ -240,7 +240,7 @@ describe("TransferManager", function () {
     });
 
     it("should return 0 as the ether value for a low priced token", async () => {
-      await tokenPriceStorage.from(infrastructure).setPrice(erc20First.contractAddress, 23000);
+      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [23000]);
       const etherValue = await getEtherValue(100, erc20First.contractAddress);
       assert.equal(etherValue.toString(), 0); // 2,300,000
     });

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -171,9 +171,13 @@ describe("TransferManager", function () {
       await assert.revertWith(transferModule.from(owner).addToWhitelist(wallet.contractAddress, recipient.address), "TT: target already whitelisted");
     });
 
-    it("should not be able to remove a non-whitelisted token from the whitelist", async () => {
-      await assert.revertWith(transferModule.from(owner).removeFromWhitelist(wallet.contractAddress, recipient.address),
-        "TT: target not whitelisted");
+    it("should be able to remove a whitelisted token from the whitelist during the security period", async () => {
+      await transferModule.from(owner).addToWhitelist(wallet.contractAddress, recipient.address);
+      await transferModule.from(owner).removeFromWhitelist(wallet.contractAddress, recipient.address);
+
+      await manager.increaseTime(3);
+      const isTrusted = await transferModule.isWhitelisted(wallet.contractAddress, recipient.address);
+      assert.equal(isTrusted, false);
     });
   });
 

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -264,7 +264,7 @@ describe("TransferManager", function () {
       // add new module
       const tx = await previousTransferModule.from(owner).addModule(existingWallet.contractAddress, transferModule.contractAddress);
       const txReceipt = await previousTransferModule.verboseWaitForTransaction(tx);
-      assert.isTrue(hasEvent(txReceipt, transferModule, "MigratedDailyLimit"));
+      assert.isTrue(hasEvent(txReceipt, transferModule, "DailyLimitMigrated"));
       // check result
       limit = await transferModule.getCurrentLimit(existingWallet.contractAddress);
       assert.equal(limit.toNumber(), 4000000, "limit should have been migrated");

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -6,7 +6,6 @@ const bnChai = require("bn-chai");
 
 const { expect } = chai;
 chai.use(bnChai(BN));
-const { assert } = require("chai");
 
 const Proxy = require("../build/Proxy");
 const BaseWallet = require("../build/BaseWallet");

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -811,17 +811,17 @@ describe("TransferManager", function () {
       await doApproveTokenAndCallContract({ amount: 10, state: 3, consumer });
     });
 
-    it("should approve token and call contract when contract != spender, amount > limit and spender is whitelisted ", async () => {
+    it("should approve token and call contract when contract != spender, amount > limit and contract is whitelisted", async () => {
       const consumer = await contract.tokenConsumer();
-      await transferModule.from(owner).addToWhitelist(wallet.contractAddress, consumer);
+      await transferModule.from(owner).addToWhitelist(wallet.contractAddress, contract.contractAddress);
       await manager.increaseTime(3);
       await doApproveTokenAndCallContract({ amount: ETH_LIMIT + 10000, state: 6, consumer });
     });
 
-    it("should fail to approve token and call contract when contract != spender, amount > limit and contract is whitelisted ", async () => {
+    it("should fail to approve token and call contract when contract != spender, amount > limit and spender is whitelisted", async () => {
       const amount = ETH_LIMIT + 10000;
       const consumer = await contract.tokenConsumer();
-      await transferModule.from(owner).addToWhitelist(wallet.contractAddress, contract.contractAddress);
+      await transferModule.from(owner).addToWhitelist(wallet.contractAddress, consumer);
       await manager.increaseTime(3);
       const dataToTransfer = contract.contract.interface.functions.setStateAndPayTokenWithConsumer.encode([6, erc20.contractAddress, amount]);
       await assert.revertWith(

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -312,7 +312,9 @@ describe("TransferManager", function () {
     });
 
     it("should be able to disable the limit", async () => {
-      await transferModule.from(owner).disableLimit(wallet.contractAddress);
+      const tx = await transferModule.from(owner).disableLimit(wallet.contractAddress);
+      const txReceipt = await transferModule.verboseWaitForTransaction(tx);
+      assert.isTrue(hasEvent(txReceipt, transferModule, "DailyLimitDisabled"));
       let limitDisabled = await transferModule.isLimitDisabled(wallet.contractAddress);
       assert.isFalse(limitDisabled);
       await manager.increaseTime(SECURITY_PERIOD + 1);

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -209,15 +209,15 @@ describe("TransferManager", function () {
     it("should set token price correctly", async () => {
       const tokenPrice = new BN(10).pow(new BN(18)).muln(1800);
       await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
-      const tokenPriceSet = await tokenPriceStorage.cachedPrices(erc20First.contractAddress);
+      const tokenPriceSet = await tokenPriceStorage.getTokenPrice(erc20First.contractAddress);
       expect(tokenPrice).to.eq.BN(tokenPriceSet.toString());
     });
 
     it("should set multiple token prices correctly", async () => {
       await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress, erc20Second.contractAddress], [1800, 1900]);
-      const tokenPrice1Set = await tokenPriceStorage.cachedPrices(erc20First.contractAddress);
+      const tokenPrice1Set = await tokenPriceStorage.getTokenPrice(erc20First.contractAddress);
       expect(1800).to.eq.BN(tokenPrice1Set.toString());
-      const tokenPrice2Set = await tokenPriceStorage.cachedPrices(erc20Second.contractAddress);
+      const tokenPrice2Set = await tokenPriceStorage.getTokenPrice(erc20Second.contractAddress);
       expect(1900).to.eq.BN(tokenPrice2Set.toString());
     });
 

--- a/utils/test-manager.js
+++ b/utils/test-manager.js
@@ -68,6 +68,13 @@ class TestManager {
     this.relayerModule = relayerModule;
   }
 
+  getChainId() {
+    if (this.network === "ganache" || this.network.endsWith("-fork")) {
+      return 1; // ganache currently always uses 1 as chainId, see https://github.com/trufflesuite/ganache-core/issues/515
+    }
+    return this.provider._network.chainId;
+  }
+
   async relay(_module, _method, _params, _wallet, _signers,
     _relayer = this.accounts[9].signer,
     _estimate = false,
@@ -85,6 +92,7 @@ class TestManager {
       _module.contractAddress,
       0,
       methodData,
+      this.getChainId(),
       nonce,
       _gasPrice,
       _gasLimit,

--- a/utils/utilities.js
+++ b/utils/utilities.js
@@ -33,7 +33,7 @@ module.exports = {
     });
   }),
 
-  signOffchain: async (signers, from, to, value, data, nonce, gasPrice, gasLimit, refundToken, refundAddress) => {
+  signOffchain: async (signers, from, to, value, data, chainId, nonce, gasPrice, gasLimit, refundToken, refundAddress) => {
     const input = `0x${[
       "0x19",
       "0x00",
@@ -41,7 +41,7 @@ module.exports = {
       to,
       ethers.utils.hexZeroPad(ethers.utils.hexlify(value), 32),
       data,
-      ethers.utils.hexZeroPad("0x01", 32), // chainId
+      ethers.utils.hexZeroPad(ethers.utils.hexlify(chainId), 32),
       nonce,
       ethers.utils.hexZeroPad(ethers.utils.hexlify(gasPrice), 32),
       ethers.utils.hexZeroPad(ethers.utils.hexlify(gasLimit), 32),

--- a/utils/utilities.js
+++ b/utils/utilities.js
@@ -41,6 +41,7 @@ module.exports = {
       to,
       ethers.utils.hexZeroPad(ethers.utils.hexlify(value), 32),
       data,
+      ethers.utils.hexZeroPad("0x01", 32), // chainId
       nonce,
       ethers.utils.hexZeroPad(ethers.utils.hexlify(gasPrice), 32),
       ethers.utils.hexZeroPad(ethers.utils.hexlify(gasLimit), 32),


### PR DESCRIPTION
Addresses the first part of issues and improvements found in the Trail of Bits audit:

1 and 6. Add an `isTradable` flag to tokens in the `TokenPriceStorage` contract and only allow trades with those "verified" tokens. `TokenPriceProvider` is updated to store the following for each token:
```
        uint184 cachedPrice;
        uint64 updatedAt;
        bool isTradable;
```
A particular token price can be changed by a manager but not more frequently than every `minPriceUpdatePeriod` which is changeable by the multisig (owner).
A token can be set to non-tradable at any time by the multisig or a manager
A token can be set to tradable at any time by the multisig

Confirmed with the backend team that 1) the backend web3 lib supports uint184 and 2) all current prices would comfortably fit in a uint184 (our biggest price uses 92 bits)

.3. Removing auto conversion of ETH into DAI when repaying Maker loan
Instead of adding the ETH-DAI purchase to the daily limit we will simply remove that functionality and force users to have the required amount of DAI to repay a loan.

.4. Add `chainID` opcode in the signature schema of meta transactions

.9. Allows the removal of a pending address whitelist request.

.10. Changes for loop counter from `uint8` to `uint256` to limit an issue for wallets with more than 510 guardians.

.11. natspec documentation fixes

.12. Relayed transactions to `ApprovedTransfer` module throw for wallets with no guardians

.13. Whitelisting contract instead of proxy (spender)

.14. isERC721 replaced with a check that the contract is not a known ERC20

.16. Refund transfers made to fail if transfer method returns false

.19. Failed transfers made to revert the subcall

.25. Added `DailyLimitMigrated`, `DailyLimitDisabled` and `LoanAcquired` events. 
todo: 
