### PR TITLE
Fix/g0 audit

### DIFF
--- a/contracts/infrastructure/ITokenPriceRegistry.sol
+++ b/contracts/infrastructure/ITokenPriceRegistry.sol
@@ -15,10 +15,10 @@
 pragma solidity ^0.6.12;
 
 /**
- * @title ITokenPriceStorage
- * @notice TokenPriceStorage interface
+ * @title ITokenPriceRegistry
+ * @notice TokenPriceRegistry interface
  */
-interface ITokenPriceStorage {
+interface ITokenPriceRegistry {
     function getTokenPrice(address _token) external view returns (uint184 _price);
     function isTokenTradable(address _token) external view returns (bool _isTradable);
 }

--- a/contracts/infrastructure/TokenPriceRegistry.sol
+++ b/contracts/infrastructure/TokenPriceRegistry.sol
@@ -16,18 +16,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.6.12;
 
-import "./ITokenPriceStorage.sol";
-import "./Storage.sol";
-import "../base/Managed.sol";
+import "./ITokenPriceRegistry.sol";
+import "./base/Managed.sol";
 
 /**
- * @title TokenPriceStorage
+ * @title TokenPriceRegistry
  * @notice Contract storing the token prices.
  * @notice Note that prices stored here = price per token * 10^(18-token decimals)
  * The contract only defines basic setters and getters with no logic.
  * Only managers of this contract can modify its state.
  */
-contract TokenPriceStorage is ITokenPriceStorage, Storage, Managed {
+contract TokenPriceRegistry is ITokenPriceRegistry, Managed {
     struct TokenInfo {
         uint184 cachedPrice;
         uint64 updatedAt;

--- a/contracts/modules/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer.sol
@@ -169,6 +169,7 @@ contract ApprovedTransfer is BaseTransfer {
         onlyAuthorisedContractCall(_wallet, _contract)
     {
         doApproveWethAndCallContract(_wallet, _spender, _amount, _contract, _data);
+        LimitUtils.resetDailySpent(versionManager, limitStorage, _wallet);
     }
 
     /**

--- a/contracts/modules/GuardianManager.sol
+++ b/contracts/modules/GuardianManager.sol
@@ -202,7 +202,7 @@ contract GuardianManager is BaseFeature {
     * @param _guardian the address to test
     * @return _isGuardian `true` if the address is a guardian for the wallet otherwise `false`.
     */
-    function isGuardianOrGuardianSigner(address _wallet, address _guardian) public view returns (bool _isGuardian) {
+    function isGuardianOrGuardianSigner(address _wallet, address _guardian) external view returns (bool _isGuardian) {
         (_isGuardian, ) = GuardianUtils.isGuardianOrGuardianSigner(guardianStorage.getGuardians(_wallet), _guardian);
     }
 

--- a/contracts/modules/GuardianManager.sol
+++ b/contracts/modules/GuardianManager.sol
@@ -197,6 +197,16 @@ contract GuardianManager is BaseFeature {
     }
 
     /**
+    * @notice Checks if an address is a guardian or an account authorised to sign on behalf of a smart-contract guardian.
+    * @param _wallet The target wallet.
+    * @param _guardian the address to test
+    * @return _isGuardian `true` if the address is a guardian for the wallet otherwise `false`.
+    */
+    function isGuardianOrGuardianSigner(address _wallet, address _guardian) public view returns (bool _isGuardian) {
+        (_isGuardian, ) = GuardianUtils.isGuardianOrGuardianSigner(guardianStorage.getGuardians(_wallet), _guardian);
+    }
+
+    /**
      * @notice Counts the number of active guardians for a wallet.
      * @param _wallet The target wallet.
      * @return _count The number of active guardians for a wallet.

--- a/contracts/modules/GuardianManager.sol
+++ b/contracts/modules/GuardianManager.sol
@@ -193,7 +193,7 @@ contract GuardianManager is BaseFeature {
      * @return _isGuardian `true` if the address is a guardian for the wallet otherwise `false`.
      */
     function isGuardian(address _wallet, address _guardian) public view returns (bool _isGuardian) {
-        (_isGuardian, ) = GuardianUtils.isGuardian(guardianStorage.getGuardians(_wallet), _guardian);
+        _isGuardian = guardianStorage.isGuardian(_wallet, _guardian);
     }
 
     /**

--- a/contracts/modules/LockManager.sol
+++ b/contracts/modules/LockManager.sol
@@ -59,7 +59,7 @@ contract LockManager is BaseFeature {
      * @notice Throws if the caller is not a guardian for the wallet.
      */
     modifier onlyGuardianOrFeature(address _wallet) {
-        (bool isGuardian, ) = GuardianUtils.isGuardian(guardianStorage.getGuardians(_wallet), msg.sender);
+        bool isGuardian = guardianStorage.isGuardian(_wallet, msg.sender);
         require(isFeatureAuthorisedInVersionManager(_wallet, msg.sender) || isGuardian, "LM: must be guardian or feature");
         _;
     }

--- a/contracts/modules/NftTransfer.sol
+++ b/contracts/modules/NftTransfer.sol
@@ -17,7 +17,7 @@
 pragma solidity ^0.6.12;
 
 import "./common/BaseFeature.sol";
-import "../infrastructure/storage/ITokenPriceStorage.sol";
+import "../infrastructure/ITokenPriceRegistry.sol";
 
 /**
  * @title NftTransfer
@@ -33,8 +33,8 @@ contract NftTransfer is BaseFeature{
 
     // The address of the CryptoKitties contract
     address public ckAddress;
-    // The token price storage
-    ITokenPriceStorage public tokenPriceStorage;
+    // The token price registry
+    ITokenPriceRegistry public tokenPriceRegistry;
 
     // *************** Events *************************** //
 
@@ -44,7 +44,7 @@ contract NftTransfer is BaseFeature{
 
     constructor(
         ILockStorage _lockStorage,
-        ITokenPriceStorage _tokenPriceStorage,
+        ITokenPriceRegistry _tokenPriceRegistry,
         IVersionManager _versionManager,
         address _ckAddress
     )
@@ -52,7 +52,7 @@ contract NftTransfer is BaseFeature{
         public
     {
         ckAddress = _ckAddress;
-        tokenPriceStorage = _tokenPriceStorage;
+        tokenPriceRegistry = _tokenPriceRegistry;
     }
 
     // *************** External/Public Functions ********************* //
@@ -135,7 +135,7 @@ contract NftTransfer is BaseFeature{
     * @param _contract The address of the contract.
      */
     function coveredByDailyLimit(address _contract) internal view returns (bool) {
-        return tokenPriceStorage.getTokenPrice(_contract) > 0;
+        return tokenPriceRegistry.getTokenPrice(_contract) > 0;
     }
 
 }

--- a/contracts/modules/RelayerManager.sol
+++ b/contracts/modules/RelayerManager.sol
@@ -22,7 +22,7 @@ import "./common/BaseFeature.sol";
 import "./common/GuardianUtils.sol";
 import "./common/LimitUtils.sol";
 import "../infrastructure/storage/ILimitStorage.sol";
-import "../infrastructure/storage/ITokenPriceStorage.sol";
+import "../infrastructure/ITokenPriceRegistry.sol";
 import "../infrastructure/storage/IGuardianStorage.sol";
 
 /**
@@ -42,7 +42,7 @@ contract RelayerManager is BaseFeature {
     // The storage of the limit
     ILimitStorage public limitStorage;
     // The Token price storage
-    ITokenPriceStorage public tokenPriceStorage;
+    ITokenPriceRegistry public tokenPriceRegistry;
     // The Guardian storage
     IGuardianStorage public guardianStorage;
 
@@ -69,14 +69,14 @@ contract RelayerManager is BaseFeature {
         ILockStorage _lockStorage,
         IGuardianStorage _guardianStorage,
         ILimitStorage _limitStorage,
-        ITokenPriceStorage _tokenPriceStorage,
+        ITokenPriceRegistry _tokenPriceRegistry,
         IVersionManager _versionManager
     )
         BaseFeature(_lockStorage, _versionManager, NAME)
         public
     {
         limitStorage = _limitStorage;
-        tokenPriceStorage = _tokenPriceStorage;
+        tokenPriceRegistry = _tokenPriceRegistry;
         guardianStorage = _guardianStorage;
     }
 
@@ -345,7 +345,7 @@ contract RelayerManager is BaseFeature {
         } else {
             gasConsumed = gasConsumed.add(10000);
             refundAmount = Utils.min(gasConsumed, _gasLimit).mul(_gasPrice);
-            uint256 ethAmount = (_refundToken == ETH_TOKEN) ? refundAmount : LimitUtils.getEtherValue(tokenPriceStorage, refundAmount, _refundToken);
+            uint256 ethAmount = (_refundToken == ETH_TOKEN) ? refundAmount : LimitUtils.getEtherValue(tokenPriceRegistry, refundAmount, _refundToken);
             require(LimitUtils.checkAndUpdateDailySpent(limitStorage, versionManager, _wallet, ethAmount), "RM: refund is above daily limit");
         }
         // refund in ETH or ERC20

--- a/contracts/modules/RelayerManager.sol
+++ b/contracts/modules/RelayerManager.sol
@@ -303,7 +303,7 @@ contract RelayerManager is BaseFeature {
                 return false; // Signers must be different
             }
             lastSigner = signer;
-            (isGuardian, guardians) = GuardianUtils.isGuardian(guardians, signer);
+            (isGuardian, guardians) = GuardianUtils.isGuardianOrGuardianSigner(guardians, signer);
             if (!isGuardian) {
                 return false;
             }

--- a/contracts/modules/TokenExchanger.sol
+++ b/contracts/modules/TokenExchanger.sol
@@ -20,7 +20,7 @@ pragma experimental ABIEncoderV2;
 import "./common/BaseFeature.sol";
 import "../../lib/other/ERC20.sol";
 import "../../lib/paraswap/IAugustusSwapper.sol";
-import "../infrastructure/storage/ITokenPriceStorage.sol";
+import "../infrastructure/ITokenPriceRegistry.sol";
 import "../infrastructure/IDexRegistry.sol";
 
 /**
@@ -50,8 +50,8 @@ contract TokenExchanger is BaseFeature {
     string public referrer;
     // Registry of authorised exchanges
     IDexRegistry public dexRegistry;
-    // The token price storage
-    ITokenPriceStorage public tokenPriceStorage;
+    // The token price registry
+    ITokenPriceRegistry public tokenPriceRegistry;
 
     event TokenExchanged(address indexed wallet, address srcToken, uint srcAmount, address destToken, uint destAmount);
 
@@ -60,7 +60,7 @@ contract TokenExchanger is BaseFeature {
 
     constructor(
         ILockStorage _lockStorage,
-        ITokenPriceStorage _tokenPriceStorage,
+        ITokenPriceRegistry _tokenPriceRegistry,
         IVersionManager _versionManager,
         IDexRegistry _dexRegistry,
         address _paraswap,
@@ -69,7 +69,7 @@ contract TokenExchanger is BaseFeature {
         BaseFeature(_lockStorage, _versionManager, NAME)
         public
     {
-        tokenPriceStorage = _tokenPriceStorage;
+        tokenPriceRegistry = _tokenPriceRegistry;
         dexRegistry = _dexRegistry;
         paraswapSwapper = _paraswap;
         paraswapProxy = IAugustusSwapper(_paraswap).getTokenTransferProxy();
@@ -181,7 +181,7 @@ contract TokenExchanger is BaseFeature {
     // Internal & Private Methods
 
     function verifyTradable(address _token) internal view {
-        require((_token == ETH_TOKEN_ADDRESS) || tokenPriceStorage.isTokenTradable(_token), "TE: Token not tradable");
+        require((_token == ETH_TOKEN_ADDRESS) || tokenPriceRegistry.isTokenTradable(_token), "TE: Token not tradable");
     }
 
     function verifyExchangeAdapters(IAugustusSwapper.Path[] calldata _path) internal view {

--- a/contracts/modules/common/GuardianUtils.sol
+++ b/contracts/modules/common/GuardianUtils.sol
@@ -29,7 +29,7 @@ library GuardianUtils {
     * @param _guardian the address to test
     * @return true and the list of guardians minus the found guardian upon success, false and the original list of guardians if not found.
     */
-    function isGuardian(address[] memory _guardians, address _guardian) internal view returns (bool, address[] memory) {
+    function isGuardianOrGuardianSigner(address[] memory _guardians, address _guardian) internal view returns (bool, address[] memory) {
         if (_guardians.length == 0 || _guardian == address(0)) {
             return (false, _guardians);
         }

--- a/contracts/modules/common/GuardianUtils.sol
+++ b/contracts/modules/common/GuardianUtils.sol
@@ -23,7 +23,7 @@ pragma solidity ^0.6.12;
 library GuardianUtils {
 
     /**
-    * @notice Checks if an address is an account guardian or an account authorised to sign on behalf of a smart-contract guardian
+    * @notice Checks if an address is a guardian or an account authorised to sign on behalf of a smart-contract guardian
     * given a list of guardians.
     * @param _guardians the list of guardians
     * @param _guardian the address to test

--- a/contracts/modules/common/LimitUtils.sol
+++ b/contracts/modules/common/LimitUtils.sol
@@ -19,7 +19,7 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../../infrastructure/storage/ILimitStorage.sol";
-import "../../infrastructure/storage/ITokenPriceStorage.sol";
+import "../../infrastructure/ITokenPriceRegistry.sol";
 import "./IVersionManager.sol";
 
 /**
@@ -150,8 +150,8 @@ library LimitUtils {
     * @param _token The address of the token.
     * @return The ether value for _amount of _token.
     */
-    function getEtherValue(ITokenPriceStorage _priceStorage, uint256 _amount, address _token) internal view returns (uint256) {
-        uint256 price = _priceStorage.getTokenPrice(_token);
+    function getEtherValue(ITokenPriceRegistry _priceRegistry, uint256 _amount, address _token) internal view returns (uint256) {
+        uint256 price = _priceRegistry.getTokenPrice(_token);
         uint256 etherValue = price.mul(_amount).div(10**18);
         return etherValue;
     }

--- a/deployment/7_upgrade_2_0.js
+++ b/deployment/7_upgrade_2_0.js
@@ -7,7 +7,7 @@ const DeployManager = require("../utils/deploy-manager.js");
 const MultisigExecutor = require("../utils/multisigexecutor.js");
 
 const LimitStorage = require("../build/LimitStorage");
-const TokenPriceStorage = require("../build/TokenPriceStorage");
+const TokenPriceRegistry = require("../build/TokenPriceRegistry");
 const LockStorage = require("../build/LockStorage");
 const DexRegistry = require("../build/DexRegistry");
 
@@ -91,8 +91,8 @@ const deploy = async (network) => {
   const LockStorageWrapper = await deployer.deploy(LockStorage);
   // Deploy the new LimitStorage
   const LimitStorageWrapper = await deployer.deploy(LimitStorage);
-  // Deploy the new TokenPriceStorage
-  const TokenPriceStorageWrapper = await deployer.deploy(TokenPriceStorage);
+  // Deploy the new TokenPriceRegistry
+  const TokenPriceRegistryWrapper = await deployer.deploy(TokenPriceRegistry);
   // Deploy the DexRegistry
   const DexRegistryWrapper = await deployer.deploy(DexRegistry);
 
@@ -155,7 +155,7 @@ const deploy = async (network) => {
     NftTransfer,
     {},
     LockStorageWrapper.contractAddress,
-    TokenPriceStorageWrapper.contractAddress,
+    TokenPriceRegistryWrapper.contractAddress,
     VersionManagerWrapper.contractAddress,
     config.CryptoKitties.contract,
   );
@@ -174,7 +174,7 @@ const deploy = async (network) => {
     TokenExchanger,
     {},
     LockStorageWrapper.contractAddress,
-    TokenPriceStorageWrapper.contractAddress,
+    TokenPriceRegistryWrapper.contractAddress,
     VersionManagerWrapper.contractAddress,
     DexRegistryWrapper.contractAddress,
     config.defi.paraswap.contract,
@@ -199,7 +199,7 @@ const deploy = async (network) => {
     LockStorageWrapper.contractAddress,
     config.modules.TransferStorage,
     LimitStorageWrapper.contractAddress,
-    TokenPriceStorageWrapper.contractAddress,
+    TokenPriceRegistryWrapper.contractAddress,
     VersionManagerWrapper.contractAddress,
     config.settings.securityPeriod || 0,
     config.settings.securityWindow || 0,
@@ -214,7 +214,7 @@ const deploy = async (network) => {
     LockStorageWrapper.contractAddress,
     config.modules.GuardianStorage,
     LimitStorageWrapper.contractAddress,
-    TokenPriceStorageWrapper.contractAddress,
+    TokenPriceRegistryWrapper.contractAddress,
     VersionManagerWrapper.contractAddress,
   );
 
@@ -255,9 +255,9 @@ const deploy = async (network) => {
     const WalletFactoryAddManagerTx = await WalletFactoryWrapper.contract.addManager(account, { gasPrice });
     await WalletFactoryWrapper.verboseWaitForTransaction(WalletFactoryAddManagerTx, `Set ${account} as the manager of the WalletFactory`);
 
-    const TokenPriceStorageAddManagerTx = await TokenPriceStorageWrapper.contract.addManager(account, { gasPrice });
-    await TokenPriceStorageWrapper.verboseWaitForTransaction(TokenPriceStorageAddManagerTx,
-      `Set ${account} as the manager of the TokenPriceStorage`);
+    const TokenPriceRegistryAddManagerTx = await TokenPriceRegistryWrapper.contract.addManager(account, { gasPrice });
+    await TokenPriceRegistryWrapper.verboseWaitForTransaction(TokenPriceRegistryAddManagerTx,
+      `Set ${account} as the manager of the TokenPriceRegistry`);
   }
 
   // //////////////////////////////////
@@ -267,8 +267,8 @@ const deploy = async (network) => {
   let changeOwnerTx = await WalletFactoryWrapper.contract.changeOwner(config.contracts.MultiSigWallet, { gasPrice });
   await WalletFactoryWrapper.verboseWaitForTransaction(changeOwnerTx, "Set the MultiSig as the owner of WalletFactory");
 
-  changeOwnerTx = await TokenPriceStorageWrapper.contract.changeOwner(config.contracts.MultiSigWallet, { gasPrice });
-  await TokenPriceStorageWrapper.verboseWaitForTransaction(changeOwnerTx, "Set the MultiSig as the owner of TokenPriceStorageWrapper");
+  changeOwnerTx = await TokenPriceRegistryWrapper.contract.changeOwner(config.contracts.MultiSigWallet, { gasPrice });
+  await TokenPriceRegistryWrapper.verboseWaitForTransaction(changeOwnerTx, "Set the MultiSig as the owner of TokenPriceRegistryWrapper");
 
   changeOwnerTx = await VersionManagerWrapper.contract.changeOwner(config.contracts.MultiSigWallet, { gasPrice });
   await VersionManagerWrapper.verboseWaitForTransaction(changeOwnerTx, "Set the MultiSig as the owner of VersionManagerWrapper");
@@ -283,7 +283,7 @@ const deploy = async (network) => {
   // TODO: change name from "module" to "feature" where appropriate
   configurator.updateModuleAddresses({
     LimitStorage: LimitStorageWrapper.contractAddress,
-    TokenPriceStorage: TokenPriceStorageWrapper.contractAddress,
+    TokenPriceRegistry: TokenPriceRegistryWrapper.contractAddress,
     LockStorage: LockStorageWrapper.contractAddress,
     ApprovedTransfer: ApprovedTransferWrapper.contractAddress,
     CompoundManager: CompoundManagerWrapper.contractAddress,
@@ -320,7 +320,7 @@ const deploy = async (network) => {
     abiUploader.upload(TransferManagerWrapper, "modules"),
     abiUploader.upload(RelayerManagerWrapper, "modules"),
     abiUploader.upload(LimitStorageWrapper, "contracts"),
-    abiUploader.upload(TokenPriceStorageWrapper, "contracts"),
+    abiUploader.upload(TokenPriceRegistryWrapper, "contracts"),
     abiUploader.upload(LockStorageWrapper, "contracts"),
     abiUploader.upload(BaseWalletWrapper, "contracts"),
     abiUploader.upload(WalletFactoryWrapper, "contracts"),

--- a/deployment/888_benchmark_2_0.js
+++ b/deployment/888_benchmark_2_0.js
@@ -25,7 +25,7 @@ const VersionManager = require("../build/VersionManager");
 const SimpleUpgrader = require("../build/SimpleUpgrader");
 const LimitStorage = require("../build/LimitStorage");
 const LockStorage = require("../build/LockStorage");
-const TokenPriceStorage = require("../build/TokenPriceStorage");
+const TokenPriceRegistry = require("../build/TokenPriceRegistry");
 const DexRegistry = require("../build/DexRegistry");
 
 const TransferManager = require("../build-legacy/v1.6.0/TransferManager");
@@ -168,7 +168,7 @@ class Benchmark {
     // Deploy Infrastructure contracts
     const LockStorageWrapper = await this.deployer.deploy(LockStorage);
     const LimitStorageWrapper = await this.deployer.deploy(LimitStorage);
-    const TokenPriceStorageWrapper = await this.deployer.deploy(TokenPriceStorage);
+    const TokenPriceRegistryWrapper = await this.deployer.deploy(TokenPriceRegistry);
     const DexRegistryWrapper = await this.deployer.deploy(DexRegistry);
 
     // Create new modules
@@ -225,7 +225,7 @@ class Benchmark {
       NewNftTransfer,
       {},
       LockStorageWrapper.contractAddress,
-      TokenPriceStorageWrapper.contractAddress,
+      TokenPriceRegistryWrapper.contractAddress,
       VersionManagerWrapper.contractAddress,
       this.config.CryptoKitties.contract,
     );
@@ -244,7 +244,7 @@ class Benchmark {
       NewTokenExchanger,
       {},
       LockStorageWrapper.contractAddress,
-      TokenPriceStorageWrapper.contractAddress,
+      TokenPriceRegistryWrapper.contractAddress,
       VersionManagerWrapper.contractAddress,
       DexRegistryWrapper.contractAddress,
       this.config.defi.paraswap.contract,
@@ -269,7 +269,7 @@ class Benchmark {
       LockStorageWrapper.contractAddress,
       this.config.modules.TransferStorage,
       LimitStorageWrapper.contractAddress,
-      TokenPriceStorageWrapper.contractAddress,
+      TokenPriceRegistryWrapper.contractAddress,
       VersionManagerWrapper.contractAddress,
       this.config.settings.securityPeriod || 0,
       this.config.settings.securityWindow || 0,
@@ -284,7 +284,7 @@ class Benchmark {
       LockStorageWrapper.contractAddress,
       this.config.modules.GuardianStorage,
       LimitStorageWrapper.contractAddress,
-      TokenPriceStorageWrapper.contractAddress,
+      TokenPriceRegistryWrapper.contractAddress,
       VersionManagerWrapper.contractAddress,
     );
 

--- a/deployment/999_benchmark.js
+++ b/deployment/999_benchmark.js
@@ -187,7 +187,7 @@ class Benchmark {
       NftTransfer,
       {},
       this.config.modules.LockStorage,
-      this.config.modules.TokenPriceStorage,
+      this.config.modules.TokenPriceRegistry,
       this.config.modules.VersionManager,
       this.config.CryptoKitties.contract,
     );
@@ -206,7 +206,7 @@ class Benchmark {
       TokenExchanger,
       {},
       this.config.modules.LockStorage,
-      this.config.modules.TokenPriceStorage,
+      this.config.modules.TokenPriceRegistry,
       this.config.modules.VersionManager,
       this.config.contracts.DexRegistry,
       this.config.defi.paraswap.contract,
@@ -231,7 +231,7 @@ class Benchmark {
       this.config.modules.LockStorage,
       this.config.modules.TransferStorage,
       this.config.modules.LimitStorage,
-      this.config.modules.TokenPriceStorage,
+      this.config.modules.TokenPriceRegistry,
       this.config.modules.VersionManager,
       this.config.settings.securityPeriod || 0,
       this.config.settings.securityWindow || 0,
@@ -246,7 +246,7 @@ class Benchmark {
       this.config.modules.LockStorage,
       this.config.modules.GuardianStorage,
       this.config.modules.LimitStorage,
-      this.config.modules.TokenPriceStorage,
+      this.config.modules.TokenPriceRegistry,
       this.config.modules.VersionManager,
     );
 

--- a/test/guardianManager.js
+++ b/test/guardianManager.js
@@ -227,7 +227,7 @@ describe("GuardianManager", function () {
       it("should let the owner add Smart Contract Guardians (blockchain transaction)", async () => {
         await guardianManager.from(owner).addGuardian(wallet.contractAddress, guardianWallet1.contractAddress);
         let count = (await guardianStorage.guardianCount(wallet.contractAddress)).toNumber();
-        let active = await guardianManager.isGuardian(wallet.contractAddress, guardian1.address);
+        let active = await guardianManager.isGuardianOrGuardianSigner(wallet.contractAddress, guardian1.address);
         assert.isTrue(active, "first guardian owner should be recognized as guardian");
         active = await guardianManager.isGuardian(wallet.contractAddress, guardianWallet1.contractAddress);
         assert.isTrue(active, "first guardian should be recognized as guardian");
@@ -235,7 +235,7 @@ describe("GuardianManager", function () {
 
         await guardianManager.from(owner).addGuardian(wallet.contractAddress, guardianWallet2.contractAddress);
         count = (await guardianStorage.guardianCount(wallet.contractAddress)).toNumber();
-        active = await guardianManager.isGuardian(wallet.contractAddress, guardian2.address);
+        active = await guardianManager.isGuardianOrGuardianSigner(wallet.contractAddress, guardian2.address);
         assert.isFalse(active, "second guardian owner should not yet be active");
         active = await guardianManager.isGuardian(wallet.contractAddress, guardianWallet2.contractAddress);
         assert.isFalse(active, "second guardian should not yet be active");
@@ -244,7 +244,7 @@ describe("GuardianManager", function () {
         await manager.increaseTime(30);
         await guardianManager.confirmGuardianAddition(wallet.contractAddress, guardianWallet2.contractAddress);
         count = (await guardianStorage.guardianCount(wallet.contractAddress)).toNumber();
-        active = await guardianManager.isGuardian(wallet.contractAddress, guardian2.address);
+        active = await guardianManager.isGuardianOrGuardianSigner(wallet.contractAddress, guardian2.address);
         assert.isTrue(active, "second guardian owner should be active");
         active = await guardianManager.isGuardian(wallet.contractAddress, guardianWallet2.contractAddress);
         assert.isTrue(active, "second guardian should be active");
@@ -256,7 +256,7 @@ describe("GuardianManager", function () {
         const count = (await guardianStorage.guardianCount(wallet.contractAddress)).toNumber();
         let active = await guardianManager.isGuardian(wallet.contractAddress, guardianWallet1.contractAddress);
         assert.isTrue(active, "first guardian should be active");
-        active = await guardianManager.isGuardian(wallet.contractAddress, guardian1.address);
+        active = await guardianManager.isGuardianOrGuardianSigner(wallet.contractAddress, guardian1.address);
         assert.isTrue(active, "first guardian owner should be active");
         assert.equal(count, 1, "1 guardian should be active");
       });

--- a/test/makerV2Manager_loan.js
+++ b/test/makerV2Manager_loan.js
@@ -22,7 +22,7 @@ const GuardianStorage = require("../build/GuardianStorage");
 const LockStorage = require("../build/LockStorage");
 const TransferStorage = require("../build/TransferStorage");
 const LimitStorage = require("../build/LimitStorage");
-const TokenPriceStorage = require("../build/TokenPriceStorage");
+const TokenPriceRegistry = require("../build/TokenPriceRegistry");
 const TransferManager = require("../build/TransferManager");
 const BadFeature = require("../build/TestFeature");
 const RelayerManager = require("../build/RelayerManager");
@@ -102,12 +102,12 @@ describe("MakerV2 Vaults", function () {
     // Deploy TransferManager
     const transferStorage = await deployer.deploy(TransferStorage);
     const limitStorage = await deployer.deploy(LimitStorage);
-    const tokenPriceStorage = await deployer.deploy(TokenPriceStorage);
+    const tokenPriceRegistry = await deployer.deploy(TokenPriceRegistry);
     transferManager = await deployer.deploy(TransferManager, {},
       lockStorage.contractAddress,
       transferStorage.contractAddress,
       limitStorage.contractAddress,
-      tokenPriceStorage.contractAddress,
+      tokenPriceRegistry.contractAddress,
       versionManager.contractAddress,
       3600,
       3600,

--- a/test/nftTransfer.js
+++ b/test/nftTransfer.js
@@ -9,7 +9,7 @@ const RelayerManager = require("../build/RelayerManager");
 const LockStorage = require("../build/LockStorage");
 const GuardianStorage = require("../build/GuardianStorage");
 const NftModule = require("../build/NftTransfer");
-const TokenPriceStorage = require("../build/TokenPriceStorage");
+const TokenPriceRegistry = require("../build/TokenPriceRegistry");
 
 const ERC721 = require("../build/TestERC721");
 const CK = require("../build/CryptoKittyTest");
@@ -43,7 +43,7 @@ describe("Token Transfer", function () {
   let ckId;
   let erc20;
   let erc20Approver;
-  let tokenPriceStorage;
+  let tokenPriceRegistry;
   let lockStorage;
   let versionManager;
 
@@ -69,11 +69,11 @@ describe("Token Transfer", function () {
       versionManager.contractAddress);
     manager.setRelayerManager(relayerManager);
     ck = await deployer.deploy(CK);
-    tokenPriceStorage = await deployer.deploy(TokenPriceStorage);
-    await tokenPriceStorage.addManager(infrastructure.address);
+    tokenPriceRegistry = await deployer.deploy(TokenPriceRegistry);
+    await tokenPriceRegistry.addManager(infrastructure.address);
     nftFeature = await deployer.deploy(NftModule, {},
       lockStorage.contractAddress,
-      tokenPriceStorage.contractAddress,
+      tokenPriceRegistry.contractAddress,
       versionManager.contractAddress,
       ck.contractAddress);
     erc20Approver = await deployer.deploy(ERC20Approver, {}, versionManager.contractAddress);
@@ -194,7 +194,7 @@ describe("Token Transfer", function () {
     describe("Protecting from transferFrom hijacking", () => {
       beforeEach(async () => {
         erc20 = await deployer.deploy(ERC20, {}, [wallet1.contractAddress], 1000, 18);
-        tokenPriceStorage.setPriceForTokenList([erc20.contractAddress], [1]);
+        tokenPriceRegistry.setPriceForTokenList([erc20.contractAddress], [1]);
         await erc20Approver.from(owner1).approveERC20(
           wallet1.contractAddress,
           erc20.contractAddress,

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -15,7 +15,7 @@ const GuardianManager = require("../build/GuardianManager");
 const GuardianStorage = require("../build/GuardianStorage");
 const LockStorage = require("../build/LockStorage");
 const LimitStorage = require("../build/LimitStorage");
-const TokenPriceStorage = require("../build/TokenPriceStorage");
+const TokenPriceRegistry = require("../build/TokenPriceRegistry");
 const ApprovedTransfer = require("../build/ApprovedTransfer");
 const RecoveryManager = require("../build/RecoveryManager"); // non-owner only feature
 const VersionManager = require("../build/VersionManager");
@@ -56,7 +56,7 @@ describe("RelayerManager", function () {
   let testFeature;
   let testFeatureNew;
   let relayerManager;
-  let tokenPriceStorage;
+  let tokenPriceRegistry;
   let limitFeature;
   let badFeature;
   let versionManager;
@@ -80,13 +80,13 @@ describe("RelayerManager", function () {
       ethers.constants.AddressZero,
       limitStorage.contractAddress);
 
-    tokenPriceStorage = await deployer.deploy(TokenPriceStorage);
-    await tokenPriceStorage.addManager(infrastructure.address);
+    tokenPriceRegistry = await deployer.deploy(TokenPriceRegistry);
+    await tokenPriceRegistry.addManager(infrastructure.address);
     relayerManager = await deployer.deploy(RelayerManager, {},
       lockStorage.contractAddress,
       guardianStorage.contractAddress,
       limitStorage.contractAddress,
-      tokenPriceStorage.contractAddress,
+      tokenPriceRegistry.contractAddress,
       versionManager.contractAddress);
     manager.setRelayerManager(relayerManager);
   });
@@ -254,7 +254,7 @@ describe("RelayerManager", function () {
       const decimals = 12; // number of decimal for TOKN contract
       const tokenRate = new BN(10).pow(new BN(19)).muln(51); // 1 TOKN = 0.00051 ETH = 0.00051*10^18 ETH wei => *10^(18-decimals) = 0.00051*10^18 * 10^6 = 0.00051*10^24 = 51*10^19
       erc20 = await deployer.deploy(ERC20, {}, [infrastructure.address], 10000000, decimals); // TOKN contract with 10M tokens (10M TOKN for account[0])
-      await tokenPriceStorage.setPriceForTokenList([erc20.contractAddress], [tokenRate.toString()]);
+      await tokenPriceRegistry.setPriceForTokenList([erc20.contractAddress], [tokenRate.toString()]);
       await limitFeature.setLimitAndDailySpent(wallet.contractAddress, 10000000000, 0);
     });
 

--- a/test/tokenExchanger.js
+++ b/test/tokenExchanger.js
@@ -33,7 +33,7 @@ const ERC20 = require("../build/TestERC20");
 const TransferStorage = require("../build/TransferStorage");
 const LimitStorage = require("../build/LimitStorage");
 const TransferManager = require("../build/TransferManager");
-const TokenPriceStorage = require("../build/TokenPriceStorage");
+const TokenPriceRegistry = require("../build/TokenPriceRegistry");
 const VersionManager = require("../build/VersionManager");
 
 // Utils
@@ -70,7 +70,7 @@ describe("Token Exchanger", function () {
   let tokenA;
   let tokenB;
   let paraswap;
-  let tokenPriceStorage;
+  let tokenPriceRegistry;
   let versionManager;
 
   before(async () => {
@@ -146,14 +146,14 @@ describe("Token Exchanger", function () {
     await whitelist.addWhitelisted(uniswapV2Adapter.contractAddress);
 
     // Deploy exchanger module
-    tokenPriceStorage = await deployer.deploy(TokenPriceStorage);
-    await tokenPriceStorage.setTradableForTokenList([tokenA.contractAddress, tokenB.contractAddress], [true, true]);
+    tokenPriceRegistry = await deployer.deploy(TokenPriceRegistry);
+    await tokenPriceRegistry.setTradableForTokenList([tokenA.contractAddress, tokenB.contractAddress], [true, true]);
     await dexRegistry.setAuthorised([kyberAdapter.contractAddress, uniswapV2Adapter.contractAddress], [true, true]);
     exchanger = await deployer.deploy(
       TokenExchanger,
       {},
       lockStorage.contractAddress,
-      tokenPriceStorage.contractAddress,
+      tokenPriceRegistry.contractAddress,
       versionManager.contractAddress,
       dexRegistry.contractAddress,
       paraswap.contractAddress,
@@ -167,7 +167,7 @@ describe("Token Exchanger", function () {
       lockStorage.contractAddress,
       transferStorage.contractAddress,
       limitStorage.contractAddress,
-      tokenPriceStorage.contractAddress,
+      tokenPriceRegistry.contractAddress,
       versionManager.contractAddress,
       3600,
       3600,
@@ -369,9 +369,9 @@ describe("Token Exchanger", function () {
         fixedAmount,
         variableAmount,
       });
-      await tokenPriceStorage.setTradableForTokenList([toToken], [false]);
+      await tokenPriceRegistry.setTradableForTokenList([toToken], [false]);
       await assert.revertWith(exchanger.from(owner)[method](...params, { gasLimit: 2000000 }), "TE: Token not tradable");
-      await tokenPriceStorage.setTradableForTokenList([toToken], [true]);
+      await tokenPriceRegistry.setTradableForTokenList([toToken], [true]);
     });
 
     it("can exclude exchanges", async () => {

--- a/test/tokenPriceStorage.js
+++ b/test/tokenPriceStorage.js
@@ -1,10 +1,10 @@
 /* global accounts */
 
-const TokenPriceStorage = require("../build/TokenPriceStorage");
+const TokenPriceRegistry = require("../build/TokenPriceRegistry");
 const ERC20 = require("../build/TestERC20");
 const TestManager = require("../utils/test-manager");
 
-describe("TokenPriceStorage", function () {
+describe("TokenPriceRegistry", function () {
   this.timeout(100000);
   const testManager = new TestManager();
   const deployer = testManager.newDeployer();
@@ -12,68 +12,68 @@ describe("TokenPriceStorage", function () {
   const manager = accounts[1].signer;
 
   let tokenAddress;
-  let tokenPriceStorage;
+  let tokenPriceRegistry;
 
   before(async () => {
     tokenAddress = (await (await deployer.deploy(ERC20, {}, [], 1, 18)).contractAddress);
   });
 
   beforeEach(async () => {
-    tokenPriceStorage = await deployer.deploy(TokenPriceStorage);
-    await tokenPriceStorage.addManager(manager.address);
-    await tokenPriceStorage.setMinPriceUpdatePeriod(3600);
+    tokenPriceRegistry = await deployer.deploy(TokenPriceRegistry);
+    await tokenPriceRegistry.addManager(manager.address);
+    await tokenPriceRegistry.setMinPriceUpdatePeriod(3600);
   });
 
   describe("Price changes", () => {
     it("lets managers change price after security period", async () => {
-      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [111111]);
-      const beforePrice = await tokenPriceStorage.getTokenPrice(tokenAddress);
+      await tokenPriceRegistry.from(manager).setPriceForTokenList([tokenAddress], [111111]);
+      const beforePrice = await tokenPriceRegistry.getTokenPrice(tokenAddress);
       assert.equal(beforePrice.toString(), "111111");
       await testManager.increaseTime(3601);
-      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222]);
-      const afterPrice = await tokenPriceStorage.getTokenPrice(tokenAddress);
+      await tokenPriceRegistry.from(manager).setPriceForTokenList([tokenAddress], [222222]);
+      const afterPrice = await tokenPriceRegistry.getTokenPrice(tokenAddress);
       assert.equal(afterPrice.toString(), "222222");
     });
     it("does not let managers change price with invalid array lengths", async () => {
-      await assert.revertWith(tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222, 333333]), "TPS: Array length mismatch");
+      await assert.revertWith(tokenPriceRegistry.from(manager).setPriceForTokenList([tokenAddress], [222222, 333333]), "TPS: Array length mismatch");
     });
     it("does not let managers change price before security period", async () => {
-      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [111111]);
+      await tokenPriceRegistry.from(manager).setPriceForTokenList([tokenAddress], [111111]);
       await testManager.increaseTime(3500);
-      await assert.revertWith(tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222]), "TPS: Price updated too early");
+      await assert.revertWith(tokenPriceRegistry.from(manager).setPriceForTokenList([tokenAddress], [222222]), "TPS: Price updated too early");
     });
     it("lets the owner change security period", async () => {
-      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [111111]);
+      await tokenPriceRegistry.from(manager).setPriceForTokenList([tokenAddress], [111111]);
       await testManager.increaseTime(1600);
-      await assert.revertWith(tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222]), "TPS: Price updated too early");
-      await tokenPriceStorage.from(owner).setMinPriceUpdatePeriod(0);
-      await tokenPriceStorage.from(manager).setPriceForTokenList([tokenAddress], [222222]);
-      const afterPrice = await tokenPriceStorage.getTokenPrice(tokenAddress);
+      await assert.revertWith(tokenPriceRegistry.from(manager).setPriceForTokenList([tokenAddress], [222222]), "TPS: Price updated too early");
+      await tokenPriceRegistry.from(owner).setMinPriceUpdatePeriod(0);
+      await tokenPriceRegistry.from(manager).setPriceForTokenList([tokenAddress], [222222]);
+      const afterPrice = await tokenPriceRegistry.getTokenPrice(tokenAddress);
       assert.equal(afterPrice.toString(), "222222");
     });
   });
 
   describe("Tradable status changes", () => {
     it("lets the owner change tradable status", async () => {
-      await tokenPriceStorage.from(owner).setTradableForTokenList([tokenAddress], [true]);
-      let tradable = await tokenPriceStorage.isTokenTradable(tokenAddress);
+      await tokenPriceRegistry.from(owner).setTradableForTokenList([tokenAddress], [true]);
+      let tradable = await tokenPriceRegistry.isTokenTradable(tokenAddress);
       assert.isTrue(tradable);
-      await tokenPriceStorage.from(owner).setTradableForTokenList([tokenAddress], [false]);
-      tradable = await tokenPriceStorage.isTokenTradable(tokenAddress);
+      await tokenPriceRegistry.from(owner).setTradableForTokenList([tokenAddress], [false]);
+      tradable = await tokenPriceRegistry.isTokenTradable(tokenAddress);
       assert.isFalse(tradable);
-      await tokenPriceStorage.from(owner).setTradableForTokenList([tokenAddress], [true]);
-      tradable = await tokenPriceStorage.isTokenTradable(tokenAddress);
+      await tokenPriceRegistry.from(owner).setTradableForTokenList([tokenAddress], [true]);
+      tradable = await tokenPriceRegistry.isTokenTradable(tokenAddress);
       assert.isTrue(tradable);
     });
     it("lets managers set tradable to false only", async () => {
-      await tokenPriceStorage.from(owner).setTradableForTokenList([tokenAddress], [true]);
-      await tokenPriceStorage.from(manager).setTradableForTokenList([tokenAddress], [false]);
-      const tradable = await tokenPriceStorage.isTokenTradable(tokenAddress);
+      await tokenPriceRegistry.from(owner).setTradableForTokenList([tokenAddress], [true]);
+      await tokenPriceRegistry.from(manager).setTradableForTokenList([tokenAddress], [false]);
+      const tradable = await tokenPriceRegistry.isTokenTradable(tokenAddress);
       assert.isFalse(tradable);
-      await assert.revertWith(tokenPriceStorage.from(manager).setTradableForTokenList([tokenAddress], [true]), "TPS: Unauthorised");
+      await assert.revertWith(tokenPriceRegistry.from(manager).setTradableForTokenList([tokenAddress], [true]), "TPS: Unauthorised");
     });
     it("does not let managers change tradable with invalid array lengths", async () => {
-      await assert.revertWith(tokenPriceStorage.from(manager).setTradableForTokenList([tokenAddress], [false, false]), "TPS: Array length mismatch");
+      await assert.revertWith(tokenPriceRegistry.from(manager).setTradableForTokenList([tokenAddress], [false, false]), "TPS: Array length mismatch");
     });
   });
 });

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -15,7 +15,7 @@ const TransferStorage = require("../build/TransferStorage");
 const LockStorage = require("../build/LockStorage");
 const GuardianStorage = require("../build/GuardianStorage");
 const LimitStorage = require("../build/LimitStorage");
-const TokenPriceStorage = require("../build/TokenPriceStorage");
+const TokenPriceRegistry = require("../build/TokenPriceRegistry");
 const RelayerManager = require("../build/RelayerManager");
 const TransferManager = require("../build/TransferManager");
 const LegacyTransferManager = require("../build-legacy/v1.6.0/TransferManager");
@@ -52,7 +52,7 @@ describe("TransferManager", function () {
   let lockStorage;
   let guardianStorage;
   let limitStorage;
-  let tokenPriceStorage;
+  let tokenPriceRegistry;
   let transferManager;
   let previousTransferManager;
   let wallet;
@@ -73,8 +73,8 @@ describe("TransferManager", function () {
     lockStorage = await deployer.deploy(LockStorage);
     guardianStorage = await deployer.deploy(GuardianStorage);
     limitStorage = await deployer.deploy(LimitStorage);
-    tokenPriceStorage = await deployer.deploy(TokenPriceStorage);
-    await tokenPriceStorage.addManager(infrastructure.address);
+    tokenPriceRegistry = await deployer.deploy(TokenPriceRegistry);
+    await tokenPriceRegistry.addManager(infrastructure.address);
     versionManager = await deployer.deploy(VersionManager, {},
       registry.contractAddress,
       lockStorage.contractAddress,
@@ -96,7 +96,7 @@ describe("TransferManager", function () {
       lockStorage.contractAddress,
       transferStorage.contractAddress,
       limitStorage.contractAddress,
-      tokenPriceStorage.contractAddress,
+      tokenPriceRegistry.contractAddress,
       versionManager.contractAddress,
       SECURITY_PERIOD,
       SECURITY_WINDOW,
@@ -112,7 +112,7 @@ describe("TransferManager", function () {
       lockStorage.contractAddress,
       guardianStorage.contractAddress,
       limitStorage.contractAddress,
-      tokenPriceStorage.contractAddress,
+      tokenPriceRegistry.contractAddress,
       versionManager.contractAddress);
     manager.setRelayerManager(relayerManager);
 
@@ -128,7 +128,7 @@ describe("TransferManager", function () {
     const tokenRate = new BN(10).pow(new BN(19)).muln(51); // 1 TOKN = 0.00051 ETH = 0.00051*10^18 ETH wei => *10^(18-decimals) = 0.00051*10^18 * 10^6 = 0.00051*10^24 = 51*10^19
 
     erc20 = await deployer.deploy(ERC20, {}, [infrastructure.address, wallet.contractAddress], 10000000, decimals); // TOKN contract with 10M tokens (5M TOKN for wallet and 5M TOKN for account[0])
-    await tokenPriceStorage.setPriceForTokenList([erc20.contractAddress], [tokenRate.toString()]);
+    await tokenPriceRegistry.setPriceForTokenList([erc20.contractAddress], [tokenRate.toString()]);
     await infrastructure.sendTransaction({ to: wallet.contractAddress, value: ethers.BigNumber.from("1000000000000000000") });
   });
 
@@ -136,7 +136,7 @@ describe("TransferManager", function () {
     if (token === ETH_TOKEN) {
       return amount;
     }
-    const price = await tokenPriceStorage.getTokenPrice(token);
+    const price = await tokenPriceRegistry.getTokenPrice(token);
     const ethPrice = new BN(price.toString()).mul(new BN(amount)).div(new BN(10).pow(new BN(18)));
     return ethPrice;
   }
@@ -147,7 +147,7 @@ describe("TransferManager", function () {
         lockStorage.contractAddress,
         transferStorage.contractAddress,
         limitStorage.contractAddress,
-        tokenPriceStorage.contractAddress,
+        tokenPriceRegistry.contractAddress,
         versionManager.contractAddress,
         SECURITY_PERIOD,
         SECURITY_WINDOW,
@@ -212,36 +212,36 @@ describe("TransferManager", function () {
 
     it("should get a token price correctly", async () => {
       const tokenPrice = new BN(10).pow(new BN(18)).muln(1800);
-      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
-      const tokenPriceSet = await tokenPriceStorage.getTokenPrice(erc20First.contractAddress);
+      await tokenPriceRegistry.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
+      const tokenPriceSet = await tokenPriceRegistry.getTokenPrice(erc20First.contractAddress);
       expect(tokenPrice).to.eq.BN(tokenPriceSet.toString());
     });
 
     it("should get multiple token prices correctly", async () => {
-      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress, erc20Second.contractAddress], [1800, 1900]);
-      const tokenPricesSet = await tokenPriceStorage.getPriceForTokenList([erc20First.contractAddress, erc20Second.contractAddress]);
+      await tokenPriceRegistry.from(infrastructure).setPriceForTokenList([erc20First.contractAddress, erc20Second.contractAddress], [1800, 1900]);
+      const tokenPricesSet = await tokenPriceRegistry.getPriceForTokenList([erc20First.contractAddress, erc20Second.contractAddress]);
       expect(1800).to.eq.BN(tokenPricesSet[0].toString());
       expect(1900).to.eq.BN(tokenPricesSet[1].toString());
     });
 
     it("should set token price correctly", async () => {
       const tokenPrice = new BN(10).pow(new BN(18)).muln(1800);
-      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
-      const tokenPriceSet = await tokenPriceStorage.getTokenPrice(erc20First.contractAddress);
+      await tokenPriceRegistry.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
+      const tokenPriceSet = await tokenPriceRegistry.getTokenPrice(erc20First.contractAddress);
       expect(tokenPrice).to.eq.BN(tokenPriceSet.toString());
     });
 
     it("should set multiple token prices correctly", async () => {
-      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress, erc20Second.contractAddress], [1800, 1900]);
-      const tokenPrice1Set = await tokenPriceStorage.getTokenPrice(erc20First.contractAddress);
+      await tokenPriceRegistry.from(infrastructure).setPriceForTokenList([erc20First.contractAddress, erc20Second.contractAddress], [1800, 1900]);
+      const tokenPrice1Set = await tokenPriceRegistry.getTokenPrice(erc20First.contractAddress);
       expect(1800).to.eq.BN(tokenPrice1Set.toString());
-      const tokenPrice2Set = await tokenPriceStorage.getTokenPrice(erc20Second.contractAddress);
+      const tokenPrice2Set = await tokenPriceRegistry.getTokenPrice(erc20Second.contractAddress);
       expect(1900).to.eq.BN(tokenPrice2Set.toString());
     });
 
     it("should be able to get the ether value of a given amount of tokens", async () => {
       const tokenPrice = new BN(10).pow(new BN(18)).muln(1800);
-      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
+      await tokenPriceRegistry.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [tokenPrice.toString()]);
       const etherValue = await getEtherValue("15000000000000000000", erc20First.contractAddress);
       // expectedValue = 1800*10^18/10^18 (price for 1 token wei) * 15*10^18 (amount) = 1800 * 15*10^18 = 27,000 * 10^18
       const expectedValue = new BN(10).pow(new BN(18)).muln(27000);
@@ -250,7 +250,7 @@ describe("TransferManager", function () {
 
     it("should be able to get the ether value for a token with 0 decimals", async () => {
       const tokenPrice = new BN(10).pow(new BN(36)).muln(23000);
-      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20ZeroDecimals.contractAddress], [tokenPrice.toString()]);
+      await tokenPriceRegistry.from(infrastructure).setPriceForTokenList([erc20ZeroDecimals.contractAddress], [tokenPrice.toString()]);
       const etherValue = await getEtherValue(100, erc20ZeroDecimals.contractAddress);
       // expectedValue = 23000*10^36 * 100 / 10^18 = 2,300,000 * 10^18
       const expectedValue = new BN(10).pow(new BN(18)).muln(2300000);
@@ -258,7 +258,7 @@ describe("TransferManager", function () {
     });
 
     it("should return 0 as the ether value for a low priced token", async () => {
-      await tokenPriceStorage.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [23000]);
+      await tokenPriceRegistry.from(infrastructure).setPriceForTokenList([erc20First.contractAddress], [23000]);
       const etherValue = await getEtherValue(100, erc20First.contractAddress);
       assert.equal(etherValue.toString(), 0); // 2,300,000
     });


### PR DESCRIPTION
Addressing the issues raised in G0 audit:
- updating `GuardianManager.isGuardian` to only check if the target address is a guardian (but not an EOA authorised to sign for a guardian)
- adding `GuardianManager.isGuardianOrGuardianSigner` to have a public method to check is a guardian or a signer for a guardian.
- renaming `TokenPriceStorage` into `TokenPriceRegistry` and removing the dependency to `Storage`.
- resetting daily spending counter after a call to `ApprovedTransfer.approveWethAndCallContract`.