### PR TITLE
Add configuration reader script

### DIFF
--- a/scripts/configReader.js
+++ b/scripts/configReader.js
@@ -37,7 +37,7 @@ async function main() {
   // This will allow the config to be printed regardless of whether it's valid or not
   await configurator.load(false);
   const configuration = configurator.copyConfig();
-  console.log(configuration);
+  console.log(JSON.stringify(configuration, null, 4));
 
   // Validate the configuration. Prints any validation error.
   configurator._validate();

--- a/scripts/configReader.js
+++ b/scripts/configReader.js
@@ -11,15 +11,12 @@
 
 require("dotenv").config();
 
-const path = require("path");
-
 const ConfiguratorLoader = require("../utils/configurator-loader.js");
 const Configurator = require("../utils/configurator.js");
 
 async function main() {
   const idx = process.argv.indexOf("--network");
   const network = process.argv[idx + 1];
-  const env = process.env.CONFIG_ENVIRONMENT;
   const remotelyManagedNetworks = (process.env.S3_BUCKET_SUFFIXES || "").split(":");
 
   // Ensure a supported network is requested

--- a/scripts/configReader.js
+++ b/scripts/configReader.js
@@ -33,9 +33,14 @@ async function main() {
   const configLoader = new ConfiguratorLoader.S3(bucket, key);
 
   const configurator = new Configurator(configLoader);
-  await configurator.load();
+
+  // This will allow the config to be printed regardless of whether it's valid or not
+  await configurator.load(false);
   const configuration = configurator.copyConfig();
   console.log(configuration);
+
+  // Validate the configuration. Prints any validation error.
+  configurator._validate();
 }
 
 main().catch((err) => {

--- a/scripts/configReader.js
+++ b/scripts/configReader.js
@@ -1,0 +1,36 @@
+// Example Usage:
+// from the project root (as we're loading .env file from root via `dotenv`)
+// bash ./scripts/execute.sh scripts/configReader.js staging
+
+require("dotenv").config();
+
+const path = require("path");
+
+const ConfiguratorLoader = require("../utils/configurator-loader.js");
+const Configurator = require("../utils/configurator.js");
+
+async function main() {
+  const idx = process.argv.indexOf("--network");
+  const network = process.argv[idx + 1];
+  const env = process.env.CONFIG_ENVIRONMENT;
+  const remotelyManagedNetworks = (process.env.S3_BUCKET_SUFFIXES || "").split(":");
+
+  let configLoader;
+  if (remotelyManagedNetworks.includes(network)) {
+    const bucket = `${process.env.S3_BUCKET_PREFIX}-${network}`;
+    const key = process.env.S3_CONFIG_KEY;
+    configLoader = new ConfiguratorLoader.S3(bucket, key);
+  } else {
+    const fileName = env ? `${network}.${env}.json` : `${network}.json`;
+    const filePath = path.join(__dirname, "./config", fileName);
+    configLoader = new ConfiguratorLoader.Local(filePath);
+  }
+  const configurator = new Configurator(configLoader);
+  await configurator.load();
+  const configuration = configurator.copyConfig();
+  console.log(configuration);
+}
+
+main().catch((err) => {
+  throw err;
+});

--- a/scripts/configReader.js
+++ b/scripts/configReader.js
@@ -1,6 +1,13 @@
-// Example Usage:
-// from the project root (as we're loading .env file from root via `dotenv`)
-// bash ./scripts/execute.sh scripts/configReader.js staging
+// ///////////////////////////////////////////////////////////////////
+// Script to print environment configuration from AWS.
+//
+// Can be executed (from the project root as we're loading .env file from root via `dotenv`) as:
+// bash ./scripts/execute_script.sh --no-compile scripts/configReader.js <network>
+//
+// where:
+//     - network = [test, staging, prod]
+// note: ganache configuration in solution under ./utils/config/ganache.json
+// ////////////////////////////////////////////////////////////////////
 
 require("dotenv").config();
 
@@ -15,16 +22,16 @@ async function main() {
   const env = process.env.CONFIG_ENVIRONMENT;
   const remotelyManagedNetworks = (process.env.S3_BUCKET_SUFFIXES || "").split(":");
 
-  let configLoader;
-  if (remotelyManagedNetworks.includes(network)) {
-    const bucket = `${process.env.S3_BUCKET_PREFIX}-${network}`;
-    const key = process.env.S3_CONFIG_KEY;
-    configLoader = new ConfiguratorLoader.S3(bucket, key);
-  } else {
-    const fileName = env ? `${network}.${env}.json` : `${network}.json`;
-    const filePath = path.join(__dirname, "./config", fileName);
-    configLoader = new ConfiguratorLoader.Local(filePath);
+  // Ensure a supported network is requested
+  if (!remotelyManagedNetworks.includes(network)) {
+    console.error("Error: Invalid network selected");
+    return;
   }
+
+  const bucket = `${process.env.S3_BUCKET_PREFIX}-${network}`;
+  const key = process.env.S3_CONFIG_KEY;
+  const configLoader = new ConfiguratorLoader.S3(bucket, key);
+
   const configurator = new Configurator(configLoader);
   await configurator.load();
   const configuration = configurator.copyConfig();


### PR DESCRIPTION
Allows us to read configuration files easily. Note that config is read without verification to allow us to read potentially invalid config. The script does the validation at the end and logs any schema validation errors. I added this logic after noticing the current staging configuration is invalid due to the missing `ArgentWalletDetector` schema property. 