### PR TITLE
Fixing isValidSignature static calls

### DIFF
--- a/contracts-test/TestFeature.sol
+++ b/contracts-test/TestFeature.sol
@@ -13,21 +13,17 @@ contract TestFeature is BaseFeature {
 
     bytes32 constant NAME = "TestFeature";
 
-    bool boolVal;
     uint uintVal;
-
     TestDapp public dapp;
 
     constructor(
         ILockStorage _lockStorage,
         IVersionManager _versionManager,
-        bool _boolVal,
         uint _uintVal
     ) 
         BaseFeature(_lockStorage, _versionManager, NAME) 
         public 
     {
-        boolVal = _boolVal;
         uintVal = _uintVal;
         dapp = new TestDapp();
     }
@@ -70,11 +66,11 @@ contract TestFeature is BaseFeature {
     }
 
     function getBoolean() public view returns (bool) {
-        return boolVal;
+        return true;
     }
 
     function getUint() public view returns (uint) {
-        return uintVal;
+        return 42;
     }
 
     function getAddress(address _addr) public pure returns (address) {

--- a/contracts/modules/VersionManager.sol
+++ b/contracts/modules/VersionManager.sol
@@ -186,7 +186,7 @@ contract VersionManager is IVersionManager, IModule, BaseFeature, Owned {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             calldatacopy(0, 0, calldatasize())
-            let result := staticcall(gas(), feature, 0, calldatasize(), 0, 0)
+            let result := delegatecall(gas(), feature, 0, calldatasize(), 0, 0)
             returndatacopy(0, 0, returndatasize())
             switch result
             case 0 {revert(0, returndatasize())}

--- a/test/baseWallet.js
+++ b/test/baseWallet.js
@@ -42,7 +42,6 @@ describe("BaseWallet", function () {
     const feature = await deployer.deploy(TestFeature, {},
       lockStorage.contractAddress,
       module.contractAddress,
-      true,
       42);
     await module.addVersion([feature.contractAddress], []);
     return { module, feature };

--- a/test/makerV2Manager_loan.js
+++ b/test/makerV2Manager_loan.js
@@ -763,7 +763,7 @@ describe("MakerV2 Vaults", function () {
 
     it("should not allow (fake) feature to give unowned vault", async () => {
       // Deploy a (fake) bad feature
-      const badFeature = await deployer.deploy(BadFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, false, 0);
+      const badFeature = await deployer.deploy(BadFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, 0);
 
       // Add the bad feature to the wallet
       await versionManager.addVersion([

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -110,8 +110,8 @@ describe("RelayerManager", function () {
       versionManager.contractAddress,
       36, 24 * 5);
 
-    testFeature = await deployer.deploy(TestFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, false, 0);
-    testFeatureNew = await deployer.deploy(TestFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, false, 0);
+    testFeature = await deployer.deploy(TestFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, 0);
+    testFeatureNew = await deployer.deploy(TestFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, 0);
 
     limitFeature = await deployer.deploy(TestLimitFeature, {},
       lockStorage.contractAddress, limitStorage.contractAddress, versionManager.contractAddress);

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -1,5 +1,5 @@
-/* global accounts */
-const { ethers, utils } = require("ethers");
+/* global accounts, utils */
+const ethers = require("ethers");
 const chai = require("chai");
 const BN = require("bn.js");
 const bnChai = require("bn-chai");
@@ -891,12 +891,12 @@ describe("TransferManager", function () {
 
   describe("Static calls", () => {
     it("should delegate isValidSignature static calls to the TransferManager", async () => {
-      const ERC1271_ISVALIDSIGNATURE_BYTES32 = utils.keccak256(utils.toUtf8Bytes("isValidSignature(bytes32,bytes)")).slice(0, 10);
+      const ERC1271_ISVALIDSIGNATURE_BYTES32 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("isValidSignature(bytes32,bytes)")).slice(0, 10);
       const isValidSignatureDelegate = await wallet.enabled(ERC1271_ISVALIDSIGNATURE_BYTES32);
       assert.equal(isValidSignatureDelegate, versionManager.contractAddress);
 
       const walletAsTransferManager = deployer.wrapDeployedContract(TransferManager, wallet.contractAddress);
-      const signHash = utils.keccak256("0x1234");
+      const signHash = ethers.utils.keccak256("0x1234");
       const sig = await personalSign(signHash, owner);
       const valid = await walletAsTransferManager.isValidSignature(signHash, sig);
       assert.equal(valid, ERC1271_ISVALIDSIGNATURE_BYTES32);

--- a/test/versionManager.js
+++ b/test/versionManager.js
@@ -59,7 +59,6 @@ describe("VersionManager", function () {
     testFeature = await deployer.deploy(TestFeature, {},
       lockStorage.contractAddress,
       versionManager.contractAddress,
-      true,
       42);
     await versionManager.addVersion([guardianManager.contractAddress, relayerManager.contractAddress, testFeature.contractAddress], []);
     manager.setRelayerManager(relayerManager);

--- a/utils/utilities.js
+++ b/utils/utilities.js
@@ -135,4 +135,6 @@ module.exports = {
       32,
     );
   },
+
+  personalSign: async (signHash, signer) => ethers.utils.joinSignature(signer.signingKey.signDigest(signHash)),
 };


### PR DESCRIPTION
EIP 1271 static calls to wallets are currently failing because `TransferManager.isValidSignature()` expects the sender to be the wallet but as of 2.1, the sender is in fact the `VersionManager`. This PR fixes the issue by having the `VersionManager` perform a `delegatecall` to the `TransferManager` instead of a `staticcall`.