### PR TITLE
Fixing EIP1271 isValidSignature static calls

### DIFF
--- a/contracts-test/TestFeature.sol
+++ b/contracts-test/TestFeature.sol
@@ -13,21 +13,17 @@ contract TestFeature is BaseFeature {
 
     bytes32 constant NAME = "TestFeature";
 
-    bool boolVal;
     uint uintVal;
-
     TestDapp public dapp;
 
     constructor(
         ILockStorage _lockStorage,
         IVersionManager _versionManager,
-        bool _boolVal,
         uint _uintVal
     ) 
         BaseFeature(_lockStorage, _versionManager, NAME) 
         public 
     {
-        boolVal = _boolVal;
         uintVal = _uintVal;
         dapp = new TestDapp();
     }
@@ -70,11 +66,11 @@ contract TestFeature is BaseFeature {
     }
 
     function getBoolean() public view returns (bool) {
-        return boolVal;
+        return true;
     }
 
     function getUint() public view returns (uint) {
-        return uintVal;
+        return 42;
     }
 
     function getAddress(address _addr) public pure returns (address) {

--- a/contracts/modules/VersionManager.sol
+++ b/contracts/modules/VersionManager.sol
@@ -186,7 +186,7 @@ contract VersionManager is IVersionManager, IModule, BaseFeature, Owned {
         // solhint-disable-next-line no-inline-assembly
         assembly {
             calldatacopy(0, 0, calldatasize())
-            let result := staticcall(gas(), feature, 0, calldatasize(), 0, 0)
+            let result := delegatecall(gas(), feature, 0, calldatasize(), 0, 0)
             returndatacopy(0, 0, returndatasize())
             switch result
             case 0 {revert(0, returndatasize())}

--- a/deployment/7_upgrade_2_1_fix.js
+++ b/deployment/7_upgrade_2_1_fix.js
@@ -16,6 +16,7 @@ const TokenExchanger = require("../build/TokenExchanger");
 const MakerV2Manager = require("../build/MakerV2Manager");
 const TransferManager = require("../build/TransferManager");
 const RelayerManager = require("../build/RelayerManager");
+const VersionManager = require("../build/VersionManager");
 
 const utils = require("../utils/utilities.js");
 

--- a/deployment/7_upgrade_2_1_fix.js
+++ b/deployment/7_upgrade_2_1_fix.js
@@ -1,0 +1,186 @@
+const semver = require("semver");
+const childProcess = require("child_process");
+const MultiSig = require("../build/MultiSigWallet");
+const ModuleRegistry = require("../build/ModuleRegistry");
+const Upgrader = require("../build/UpgraderToVersionManager");
+const DeployManager = require("../utils/deploy-manager.js");
+const MultisigExecutor = require("../utils/multisigexecutor.js");
+
+const VersionManager = require("../build/VersionManager");
+
+const utils = require("../utils/utilities.js");
+
+const TARGET_VERSION = "2.1.0";
+const MODULES_TO_ENABLE = [
+  "VersionManager",
+];
+const MODULES_TO_DISABLE = [];
+
+const BACKWARD_COMPATIBILITY = 4;
+
+const deploy = async (network) => {
+  if (!["kovan", "kovan-fork", "staging", "prod"].includes(network)) {
+    console.warn("------------------------------------------------------------------------");
+    console.warn(`WARNING: The MakerManagerV2 module is not fully functional on ${network}`);
+    console.warn("------------------------------------------------------------------------");
+  }
+
+  const newModuleWrappers = [];
+  const newVersion = {};
+
+  // //////////////////////////////////
+  // Setup
+  // //////////////////////////////////
+
+  const manager = new DeployManager(network);
+  await manager.setup();
+
+  const { configurator } = manager;
+  const { deployer } = manager;
+  const { abiUploader } = manager;
+  const { versionUploader } = manager;
+  const { gasPrice } = deployer.defaultOverrides;
+  const deploymentWallet = deployer.signer;
+  const { config } = configurator;
+
+  const ModuleRegistryWrapper = await deployer.wrapDeployedContract(ModuleRegistry, config.contracts.ModuleRegistry);
+  const MultiSigWrapper = await deployer.wrapDeployedContract(MultiSig, config.contracts.MultiSigWallet);
+  const multisigExecutor = new MultisigExecutor(MultiSigWrapper, deploymentWallet, config.multisig.autosign, { gasPrice });
+
+  // //////////////////////////////////
+  // Deploy new modules
+  // //////////////////////////////////
+
+  const VersionManagerWrapper = await deployer.deploy(
+    VersionManager,
+    {},
+    config.contracts.ModuleRegistry,
+    config.modules.LockStorage,
+    config.modules.GuardianStorage,
+    config.modules.TransferStorage,
+    config.modules.LimitStorage,
+  );
+  newModuleWrappers.push(VersionManagerWrapper);
+
+  // Add Features to Version Manager
+  const features = [
+    config.modules.GuardianManager,
+    config.modules.LockManager,
+    config.modules.RecoveryManager,
+    config.modules.ApprovedTransfer,
+    config.modules.TransferManager,
+    config.modules.TokenExchanger,
+    config.modules.NftTransfer,
+    config.modules.CompoundManager,
+    config.modules.MakerV2Manager,
+    config.modules.RelayerManager,
+  ];
+  const featuresWithNoInit = [ // all features except the TransferManager
+    config.modules.GuardianManager,
+    config.modules.LockManager,
+    config.modules.RecoveryManager,
+    config.modules.ApprovedTransfer,
+    config.modules.TokenExchanger,
+    config.modules.NftTransfer,
+    config.modules.CompoundManager,
+    config.modules.MakerV2Manager,
+    config.modules.RelayerManager,
+  ];
+  const featureToInit = features.filter((f) => !featuresWithNoInit.includes(f));
+  const VersionManagerAddVersionTx = await VersionManagerWrapper.contract.addVersion(features, featureToInit, { gasPrice });
+  await VersionManagerWrapper.verboseWaitForTransaction(VersionManagerAddVersionTx, "Adding New Version");
+
+  // //////////////////////////////////
+  // Set contracts' owners
+  // //////////////////////////////////
+
+  const changeOwnerTx = await VersionManagerWrapper.contract.changeOwner(config.contracts.MultiSigWallet, { gasPrice });
+  await VersionManagerWrapper.verboseWaitForTransaction(changeOwnerTx, "Set the MultiSig as the owner of VersionManagerWrapper");
+
+  // /////////////////////////////////////////////////
+  // Update config and Upload ABIs
+  // /////////////////////////////////////////////////
+
+  configurator.updateModuleAddresses({
+    VersionManager: VersionManagerWrapper.contractAddress,
+  });
+
+  const gitHash = childProcess.execSync("git rev-parse HEAD").toString("utf8").replace(/\n$/, "");
+  configurator.updateGitHash(gitHash);
+  await configurator.save();
+
+  await Promise.all([
+    abiUploader.upload(VersionManagerWrapper, "modules"),
+  ]);
+
+  // //////////////////////////////////
+  // Register new modules
+  // //////////////////////////////////
+
+  for (let idx = 0; idx < newModuleWrappers.length; idx += 1) {
+    const wrapper = newModuleWrappers[idx];
+    await multisigExecutor.executeCall(ModuleRegistryWrapper, "registerModule",
+      [wrapper.contractAddress, utils.asciiToBytes32(wrapper._contract.contractName)]);
+  }
+
+  // //////////////////////////////////
+  // Deploy and Register upgraders
+  // //////////////////////////////////
+
+  let fingerprint;
+  const versions = await versionUploader.load(BACKWARD_COMPATIBILITY);
+  for (let idx = 0; idx < versions.length; idx += 1) {
+    const version = versions[idx];
+    let toAdd; let toRemove;
+    if (idx === 0) {
+      const moduleNamesToRemove = MODULES_TO_DISABLE.concat(MODULES_TO_ENABLE);
+      toRemove = version.modules.filter((module) => moduleNamesToRemove.includes(module.name));
+      toAdd = newModuleWrappers.map((wrapper) => ({
+        address: wrapper.contractAddress,
+        name: wrapper._contract.contractName,
+      }));
+      const toKeep = version.modules.filter((module) => !moduleNamesToRemove.includes(module.name));
+      const modulesInNewVersion = toKeep.concat(toAdd);
+      fingerprint = utils.versionFingerprint(modulesInNewVersion);
+      newVersion.version = semver.lt(version.version, TARGET_VERSION) ? TARGET_VERSION : semver.inc(version.version, "patch");
+      newVersion.createdAt = Math.floor((new Date()).getTime() / 1000);
+      newVersion.modules = modulesInNewVersion;
+      newVersion.fingerprint = fingerprint;
+    } else {
+      // add all modules present in newVersion that are not present in version
+      toAdd = newVersion.modules.filter((module) => !version.modules.map((m) => m.address).includes(module.address));
+      // remove all modules from version that are no longer present in newVersion
+      toRemove = version.modules.filter((module) => !newVersion.modules.map((m) => m.address).includes(module.address));
+    }
+
+    const upgraderName = `${version.fingerprint}_${fingerprint}`;
+
+    // if upgrading from a version strictly older than 2.1 (toRemove.length > 1), we use the "old LockStorage",
+    // which was part of the GuardianStorage prior to 2.1. Otherwise (toRemove.length === 1), we use the new LockStorage introduced in 2.1
+    const lockStorage = (toRemove.length === 1) ? config.modules.LockStorage : config.modules.GuardianStorage;
+
+    const UpgraderWrapper = await deployer.deploy(
+      Upgrader,
+      {},
+      config.contracts.ModuleRegistry,
+      lockStorage,
+      toRemove.map((module) => module.address),
+      VersionManagerWrapper.contractAddress, // to add
+    );
+    await multisigExecutor.executeCall(ModuleRegistryWrapper, "registerModule",
+      [UpgraderWrapper.contractAddress, utils.asciiToBytes32(upgraderName)]);
+
+    await multisigExecutor.executeCall(ModuleRegistryWrapper, "registerUpgrader",
+      [UpgraderWrapper.contractAddress, utils.asciiToBytes32(upgraderName)]);
+  }
+
+  // //////////////////////////////////
+  // Upload Version
+  // //////////////////////////////////
+
+  await versionUploader.upload(newVersion);
+};
+
+module.exports = {
+  deploy,
+};

--- a/deployment/7_upgrade_2_2.js
+++ b/deployment/7_upgrade_2_2.js
@@ -20,7 +20,7 @@ const VersionManager = require("../build/VersionManager");
 
 const utils = require("../utils/utilities.js");
 
-const TARGET_VERSION = "2.1.0";
+const TARGET_VERSION = "2.2.0";
 const MODULES_TO_ENABLE = [
   "VersionManager",
 ];

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:coverage": "bash ./scripts/provision_lib_artefacts.sh & npx etherlime coverage && istanbul check-coverage --statements 94 --branches 83 --functions 96 --lines 94",
     "lint:js": "eslint .",
     "lint:contracts": "npx solhint contracts/**/*.sol && npx solhint contracts/**/**/*.sol",
-    "test:deployment": "./scripts/deploy.sh ganache `seq 1 6`",
+    "test:deployment": "./scripts/deploy.sh ganache `seq 1 7`",
     "test:benchmark": "./scripts/deploy.sh ganache 999",
     "security:slither": "npm run security:slither:infrastructure && npm run security:slither:modules",
     "security:slither:infrastructure": "rm -rf build && npm run compile:infrastructure && slither . --ignore-compile --filter-paths lib --solc-disable-warnings --exclude-low --exclude-informational --exclude=naming-convention,unused-state-variables,solc-version,assembly-usage,low-level-calls,public-function-that-could-be-declared-as-external",

--- a/test/baseWallet.js
+++ b/test/baseWallet.js
@@ -42,7 +42,6 @@ describe("BaseWallet", function () {
     const feature = await deployer.deploy(TestFeature, {},
       lockStorage.contractAddress,
       module.contractAddress,
-      true,
       42);
     await module.addVersion([feature.contractAddress], []);
     return { module, feature };

--- a/test/makerV2Manager_loan.js
+++ b/test/makerV2Manager_loan.js
@@ -763,7 +763,7 @@ describe("MakerV2 Vaults", function () {
 
     it("should not allow (fake) feature to give unowned vault", async () => {
       // Deploy a (fake) bad feature
-      const badFeature = await deployer.deploy(BadFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, false, 0);
+      const badFeature = await deployer.deploy(BadFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, 0);
 
       // Add the bad feature to the wallet
       await versionManager.addVersion([

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -110,8 +110,8 @@ describe("RelayerManager", function () {
       versionManager.contractAddress,
       36, 24 * 5);
 
-    testFeature = await deployer.deploy(TestFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, false, 0);
-    testFeatureNew = await deployer.deploy(TestFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, false, 0);
+    testFeature = await deployer.deploy(TestFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, 0);
+    testFeatureNew = await deployer.deploy(TestFeature, {}, lockStorage.contractAddress, versionManager.contractAddress, 0);
 
     limitFeature = await deployer.deploy(TestLimitFeature, {},
       lockStorage.contractAddress, limitStorage.contractAddress, versionManager.contractAddress);

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -1,5 +1,5 @@
-/* global accounts */
-const { ethers, utils } = require("ethers");
+/* global accounts, utils */
+const ethers = require("ethers");
 const chai = require("chai");
 const BN = require("bn.js");
 const bnChai = require("bn-chai");
@@ -891,12 +891,12 @@ describe("TransferManager", function () {
 
   describe("Static calls", () => {
     it("should delegate isValidSignature static calls to the TransferManager", async () => {
-      const ERC1271_ISVALIDSIGNATURE_BYTES32 = utils.keccak256(utils.toUtf8Bytes("isValidSignature(bytes32,bytes)")).slice(0, 10);
+      const ERC1271_ISVALIDSIGNATURE_BYTES32 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("isValidSignature(bytes32,bytes)")).slice(0, 10);
       const isValidSignatureDelegate = await wallet.enabled(ERC1271_ISVALIDSIGNATURE_BYTES32);
       assert.equal(isValidSignatureDelegate, versionManager.contractAddress);
 
       const walletAsTransferManager = deployer.wrapDeployedContract(TransferManager, wallet.contractAddress);
-      const signHash = utils.keccak256("0x1234");
+      const signHash = ethers.utils.keccak256("0x1234");
       const sig = await personalSign(signHash, owner);
       const valid = await walletAsTransferManager.isValidSignature(signHash, sig);
       assert.equal(valid, ERC1271_ISVALIDSIGNATURE_BYTES32);

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -901,5 +901,23 @@ describe("TransferManager", function () {
       const valid = await walletAsTransferManager.isValidSignature(signHash, sig);
       assert.equal(valid, ERC1271_ISVALIDSIGNATURE_BYTES32);
     });
+    it("should revert isValidSignature static call for invalid signature", async () => {
+      const walletAsTransferManager = deployer.wrapDeployedContract(TransferManager, wallet.contractAddress);
+      const signHash = ethers.utils.keccak256("0x1234");
+      const sig = `${await personalSign(signHash, owner)}a1`;
+
+      await assert.revertWith(
+        walletAsTransferManager.isValidSignature(signHash, sig), "TM: invalid signature length",
+      );
+    });
+    it("should revert isValidSignature static call for invalid signer", async () => {
+      const walletAsTransferManager = deployer.wrapDeployedContract(TransferManager, wallet.contractAddress);
+      const signHash = ethers.utils.keccak256("0x1234");
+      const sig = await personalSign(signHash, nonowner);
+
+      await assert.revertWith(
+        walletAsTransferManager.isValidSignature(signHash, sig), "TM: Invalid signer",
+      );
+    });
   });
 });

--- a/test/versionManager.js
+++ b/test/versionManager.js
@@ -59,7 +59,6 @@ describe("VersionManager", function () {
     testFeature = await deployer.deploy(TestFeature, {},
       lockStorage.contractAddress,
       versionManager.contractAddress,
-      true,
       42);
     await versionManager.addVersion([guardianManager.contractAddress, relayerManager.contractAddress, testFeature.contractAddress], []);
     manager.setRelayerManager(relayerManager);

--- a/utils/utilities.js
+++ b/utils/utilities.js
@@ -135,4 +135,6 @@ module.exports = {
       32,
     );
   },
+
+  personalSign: async (signHash, signer) => ethers.utils.joinSignature(signer.signingKey.signDigest(signHash)),
 };

--- a/utils/utilities.js
+++ b/utils/utilities.js
@@ -137,4 +137,13 @@ module.exports = {
   },
 
   personalSign: async (signHash, signer) => ethers.utils.joinSignature(signer.signingKey.signDigest(signHash)),
+
+  callStatic: async (contractWrapper, method, ...args) => {
+    const contract = new ethers.Contract(
+      contractWrapper.contractAddress,
+      contractWrapper.contract.interface.abi,
+      ethers.getDefaultProvider(contractWrapper.provider.connection.url),
+    );
+    return contract.callStatic[method](...args);
+  },
 };


### PR DESCRIPTION
EIP 1271 static calls to wallets are currently failing because `TransferManager.isValidSignature()` expects the sender to be the wallet but as of 2.1, the sender is in fact the `VersionManager`. This PR fixes the issue by having the `VersionManager` perform a `delegatecall` to the `TransferManager` instead of a `staticcall`.