### PR TITLE
Independently compile contracts that fail verification

### DIFF
--- a/contracts/modules/ApprovedTransfer/ApprovedTransfer.sol
+++ b/contracts/modules/ApprovedTransfer/ApprovedTransfer.sol
@@ -17,11 +17,11 @@
 pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
-import "./common/Utils.sol";
-import "./common/LimitUtils.sol";
-import "./common/BaseTransfer.sol";
-import "../infrastructure/storage/ILimitStorage.sol";
-import "../infrastructure/storage/IGuardianStorage.sol";
+import "../common/Utils.sol";
+import "../common/LimitUtils.sol";
+import "../common/BaseTransfer.sol";
+import "../../infrastructure/storage/ILimitStorage.sol";
+import "../../infrastructure/storage/IGuardianStorage.sol";
 
 /**
  * @title ApprovedTransfer

--- a/contracts/modules/RelayerManager/RelayerManager.sol
+++ b/contracts/modules/RelayerManager/RelayerManager.sol
@@ -17,13 +17,13 @@
 pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
-import "./common/Utils.sol";
-import "./common/BaseFeature.sol";
-import "./common/GuardianUtils.sol";
-import "./common/LimitUtils.sol";
-import "../infrastructure/storage/ILimitStorage.sol";
-import "../infrastructure/ITokenPriceRegistry.sol";
-import "../infrastructure/storage/IGuardianStorage.sol";
+import "../common/Utils.sol";
+import "../common/BaseFeature.sol";
+import "../common/GuardianUtils.sol";
+import "../common/LimitUtils.sol";
+import "../../infrastructure/storage/ILimitStorage.sol";
+import "../../infrastructure/ITokenPriceRegistry.sol";
+import "../../infrastructure/storage/IGuardianStorage.sol";
 
 /**
  * @title RelayerManager

--- a/contracts/modules/TokenExchanger/TokenExchanger.sol
+++ b/contracts/modules/TokenExchanger/TokenExchanger.sol
@@ -17,11 +17,11 @@
 pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
-import "./common/BaseFeature.sol";
-import "../../lib/other/ERC20.sol";
-import "../../lib/paraswap/IAugustusSwapper.sol";
-import "../infrastructure/ITokenPriceRegistry.sol";
-import "../infrastructure/IDexRegistry.sol";
+import "../common/BaseFeature.sol";
+import "../../../lib/other/ERC20.sol";
+import "../../../lib/paraswap/IAugustusSwapper.sol";
+import "../../infrastructure/ITokenPriceRegistry.sol";
+import "../../infrastructure/IDexRegistry.sol";
 
 /**
  * @title TokenExchanger

--- a/contracts/modules/TransferManager/TransferManager.sol
+++ b/contracts/modules/TransferManager/TransferManager.sol
@@ -17,13 +17,13 @@
 pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
-import "./common/Utils.sol";
-import "./common/BaseTransfer.sol";
-import "./common/LimitUtils.sol";
-import "../infrastructure/storage/ILimitStorage.sol";
-import "../infrastructure/storage/ITransferStorage.sol";
-import "../infrastructure/ITokenPriceRegistry.sol";
-import "../../lib/other/ERC20.sol";
+import "../common/Utils.sol";
+import "../common/BaseTransfer.sol";
+import "../common/LimitUtils.sol";
+import "../../infrastructure/storage/ILimitStorage.sol";
+import "../../infrastructure/storage/ITransferStorage.sol";
+import "../../infrastructure/ITokenPriceRegistry.sol";
+import "../../../lib/other/ERC20.sol";
 
 /**
  * @title TransferManager

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "compile:infrastructure_0.5": "npx etherlime compile --workingDirectory contracts/infrastructure_0.5 --solcVersion 0.5.4 --runs=999",
     "compile:infrastructure_0.6": "npx etherlime compile --workingDirectory contracts/infrastructure --runs=999",
     "compile:infrastructure": "npm run compile:infrastructure_0.5 && npm run compile:infrastructure_0.6",
-    "compile:modules": "npx etherlime compile --workingDirectory contracts/modules --runs=999",
+    "compile:modules": "npx etherlime compile --workingDirectory contracts/modules --runs=999 && npx etherlime compile --workingDirectory contracts/modules/ApprovedTransfer --runs=999 && npx etherlime compile --workingDirectory contracts/modules/RelayerManager --runs=999 && npx etherlime compile --workingDirectory contracts/modules/TransferManager --runs=999 && npx etherlime compile --workingDirectory contracts/modules/TokenExchanger --runs=999",
     "compile:wallet": "npx etherlime compile --workingDirectory contracts/wallet --runs=999",
     "compile:test": "npx etherlime compile --workingDirectory contracts-test --runs=999",
     "compile": "npm run compile:infrastructure && npm run compile:modules && npm run compile:wallet",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "compile:infrastructure_0.5": "npx etherlime compile --workingDirectory contracts/infrastructure_0.5 --solcVersion 0.5.4 --runs=999",
     "compile:infrastructure_0.6": "npx etherlime compile --workingDirectory contracts/infrastructure --runs=999",
     "compile:infrastructure": "npm run compile:infrastructure_0.5 && npm run compile:infrastructure_0.6",
-    "compile:modules": "npx etherlime compile --workingDirectory contracts/modules --runs=999 && npx etherlime compile --workingDirectory contracts/modules/ApprovedTransfer --runs=999 && npx etherlime compile --workingDirectory contracts/modules/RelayerManager --runs=999 && npx etherlime compile --workingDirectory contracts/modules/TransferManager --runs=999 && npx etherlime compile --workingDirectory contracts/modules/TokenExchanger --runs=999",
+    "compile:modules": "npx etherlime compile --workingDirectory contracts/modules --runs=999 && rm build/ApprovedTransfer.json && npx etherlime compile --workingDirectory contracts/modules/ApprovedTransfer --runs=999 && rm build/RelayerManager.json && npx etherlime compile --workingDirectory contracts/modules/RelayerManager --runs=999 && rm build/TransferManager.json && npx etherlime compile --workingDirectory contracts/modules/TransferManager --runs=999 && rm build/TokenExchanger.json && npx etherlime compile --workingDirectory contracts/modules/TokenExchanger --runs=999",
     "compile:wallet": "npx etherlime compile --workingDirectory contracts/wallet --runs=999",
     "compile:test": "npx etherlime compile --workingDirectory contracts-test --runs=999",
     "compile": "npm run compile:infrastructure && npm run compile:modules && npm run compile:wallet",


### PR DESCRIPTION
Due to https://github.com/ethereum/solidity/issues/9573#issuecomment-721632715 we have to independently compile features that use the `ABIEncoderV2`. This is more difficult with `etherlime` as that doesn't accept single contracts as compile targets so we've had to isolate these contracts in their own folders. This will be eliminated with the migration to `truffle` in the next release. 