### PR TITLE
Authenticate docker pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,16 @@ version: 2
 job_common: &job_common
   docker:
     - image: circleci/node:10.21-stretch
+      auth:
+          username: argentcircleci
+          password: $DOCKERHUB_PASSWORD
   working_directory: ~/argent-contracts
 job_python: &job_python
   docker:
     - image: circleci/python:3.8.0b1-stretch-node
+      auth:
+        username: argentcircleci
+        password: $DOCKERHUB_PASSWORD
   working_directory: ~/argent-contracts
 step_save_cache: &step_save_cache
   save_cache:


### PR DESCRIPTION
On November 1st, Docker Hub began limiting anonymous image pulls. Because the anonymous API rate limits are based on IP addresses, they impact CircleCI cloud users. Authenticated users get higher per-user rate limits, regardless of IP.

To minimise disruptions we add authentication to the Circle builds here. 
