### PR TITLE
Accurate gas estimation for relayed transactions

### DIFF
--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -75,7 +75,7 @@ contract("ApprovedTransfer", (accounts) => {
       limitStorage.address,
       ethers.constants.AddressZero,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
     walletImplementation = await BaseWallet.new();
 
     limitFeature = await TestLimitFeature.new(

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -1,4 +1,5 @@
 /* global artifacts */
+const { assert } = require("chai");
 const ethers = require("ethers");
 const truffleAssert = require("truffle-assertions");
 
@@ -318,8 +319,9 @@ contract("ApprovedTransfer", (accounts) => {
           const txReceipt = await manager.relay(approvedTransfer, "approveTokenAndCallContract",
             [wallet.address, erc20.address, wallet.address, amountToApprove, target.address, invalidData],
             wallet, [owner, ...sortWalletByAddress([guardian1, guardian2])]);
-          const { success } = parseRelayReceipt(txReceipt);
+          const { success, error } = parseRelayReceipt(txReceipt);
           assert.isFalse(success);
+          assert.equal(error, "BT: Forbidden contract");
         }
 
         it("should revert when target contract is the wallet", async () => {

--- a/test/approvedTransfer.js
+++ b/test/approvedTransfer.js
@@ -1,5 +1,4 @@
 /* global artifacts */
-const { assert } = require("chai");
 const ethers = require("ethers");
 const truffleAssert = require("truffle-assertions");
 

--- a/test/compoundManager_invest.js
+++ b/test/compoundManager_invest.js
@@ -142,7 +142,7 @@ contract("Invest Manager with Compound", (accounts) => {
       ethers.constants.AddressZero,
       ethers.constants.AddressZero,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     await versionManager.addVersion([
       investManager.address,

--- a/test/compoundManager_loan.js
+++ b/test/compoundManager_loan.js
@@ -615,7 +615,7 @@ contract("Loan Module", (accounts) => {
         const params = [wallet.address, loanId];
         let txReceipt;
         if (relayed) {
-          txReceipt = await manager.relay(loanManager, method, params, wallet, [owner], accounts[9], false, 2000000);
+          txReceipt = await manager.relay(loanManager, method, params, wallet, [owner]);
         } else {
           const tx = await loanManager[method](...params, { from: owner });
           txReceipt = tx.receipt;

--- a/test/compoundManager_loan.js
+++ b/test/compoundManager_loan.js
@@ -162,7 +162,7 @@ contract("Loan Module", (accounts) => {
       ethers.constants.AddressZero,
       ethers.constants.AddressZero,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     await versionManager.addVersion([
       loanManager.address,

--- a/test/guardianManager.js
+++ b/test/guardianManager.js
@@ -62,7 +62,7 @@ contract("GuardianManager", (accounts) => {
       24,
       12);
     await versionManager.addVersion([guardianManager.address, relayerManager.address], []);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     const proxy = await Proxy.new(walletImplementation.address);
     wallet = await BaseWallet.at(proxy.address);

--- a/test/lockManager.js
+++ b/test/lockManager.js
@@ -76,7 +76,7 @@ contract("LockManager", (accounts) => {
       ethers.constants.AddressZero,
       ethers.constants.AddressZero,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     const proxy = await Proxy.new(walletImplementation.address);
     wallet = await BaseWallet.at(proxy.address);

--- a/test/makerV2Manager_invest.js
+++ b/test/makerV2Manager_invest.js
@@ -80,7 +80,7 @@ contract("MakerV2Invest", (accounts) => {
       ethers.constants.AddressZero,
       ethers.constants.AddressZero,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     await versionManager.addVersion([makerV2.address, relayerManager.address], []);
   });

--- a/test/makerV2Manager_loan.js
+++ b/test/makerV2Manager_loan.js
@@ -125,7 +125,7 @@ contract("MakerV2Loan", (accounts) => {
       ethers.constants.AddressZero,
       ethers.constants.AddressZero,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     await versionManager.addVersion([
       makerV2.address,

--- a/test/nftTransfer.js
+++ b/test/nftTransfer.js
@@ -112,7 +112,7 @@ contract("NftTransfer", (accounts) => {
         if (shouldSucceed) {
           await txPromise;
         } else {
-          truffleAssert.reverts(txPromise, expectedError);
+          await truffleAssert.reverts(txPromise, expectedError);
         }
       }
       if (shouldSucceed) {
@@ -154,7 +154,7 @@ contract("NftTransfer", (accounts) => {
         await testNftTransfer({ safe: false, relayed: true, recipientAddress: wallet2.address });
       });
 
-      it("should allow safe NFT transfer from wallet1 to wallet2 (relayed)", async () => {
+      it.skip("should allow safe NFT transfer from wallet1 to wallet2 (relayed)", async () => {
         await testNftTransfer({ safe: true, relayed: true, recipientAddress: wallet2.address });
       });
     });

--- a/test/nftTransfer.js
+++ b/test/nftTransfer.js
@@ -154,7 +154,7 @@ contract("NftTransfer", (accounts) => {
         await testNftTransfer({ safe: false, relayed: true, recipientAddress: wallet2.address });
       });
 
-      it.skip("should allow safe NFT transfer from wallet1 to wallet2 (relayed)", async () => {
+      it("should allow safe NFT transfer from wallet1 to wallet2 (relayed)", async () => {
         await testNftTransfer({ safe: true, relayed: true, recipientAddress: wallet2.address });
       });
     });

--- a/test/nftTransfer.js
+++ b/test/nftTransfer.js
@@ -63,7 +63,7 @@ contract("NftTransfer", (accounts) => {
       ethers.constants.AddressZero,
       ethers.constants.AddressZero,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
     ck = await CK.new();
     tokenPriceRegistry = await TokenPriceRegistry.new();
     await tokenPriceRegistry.addManager(infrastructure);

--- a/test/nftTransfer.js
+++ b/test/nftTransfer.js
@@ -103,7 +103,7 @@ contract("NftTransfer", (accounts) => {
         assert.isTrue(success);
       } else {
         await nftFeature.transferNFT(wallet1.address, nftContract.address, recipientAddress, nftId, safe, ZERO_BYTES32,
-          { from: owner1, gasLimit: 300000 });
+          { from: owner1 });
       }
 
       const afterWallet1 = await nftContract.balanceOf(wallet1.address);

--- a/test/recoveryManager.js
+++ b/test/recoveryManager.js
@@ -79,7 +79,7 @@ contract("RecoveryManager", (accounts) => {
       ethers.constants.AddressZero,
       ethers.constants.AddressZero,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     const proxy = await Proxy.new(walletImplementation.address);
     wallet = await BaseWallet.at(proxy.address);

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -181,8 +181,6 @@ contract("RelayerManager", (accounts) => {
         params,
         wallet,
         [owner],
-        accounts[9],
-        false,
         gasLimit,
         nonce,
         0,
@@ -202,8 +200,7 @@ contract("RelayerManager", (accounts) => {
     it("should fail a duplicate transaction", async () => {
       const params = [wallet.address, 2];
       const nonce = await utils.getNonceForRelay();
-      const relayParams = [testFeature, "setIntOwnerOnly", params, wallet, [owner],
-        accounts[9], false, 2000000, nonce];
+      const relayParams = [testFeature, "setIntOwnerOnly", params, wallet, [owner], 2000000, nonce];
       await manager.relay(...relayParams);
       await truffleAssert.reverts(
         manager.relay(...relayParams), "RM: Duplicate request",
@@ -232,8 +229,7 @@ contract("RelayerManager", (accounts) => {
 
     it("should update the nonce after the transaction", async () => {
       const nonce = await utils.getNonceForRelay();
-      await manager.relay(testFeature, "setIntOwnerOnly", [wallet.address, 2], wallet, [owner],
-        accounts[9], false, 2000000, nonce);
+      await manager.relay(testFeature, "setIntOwnerOnly", [wallet.address, 2], wallet, [owner], 2000000, nonce);
 
       const updatedNonce = await relayerManager.getNonce(wallet.address);
       const updatedNonceHex = await updatedNonce.toString(16, 32);
@@ -268,8 +264,6 @@ contract("RelayerManager", (accounts) => {
         [wallet.address, 2],
         wallet,
         [owner],
-        accounts[9],
-        false,
         2000000,
         nonce,
         10,
@@ -352,8 +346,6 @@ contract("RelayerManager", (accounts) => {
         params,
         wallet,
         [owner, guardian],
-        accounts[9],
-        false,
         gasLimit,
         nonce,
         0,

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -169,7 +169,7 @@ contract("RelayerManager", (accounts) => {
       ], []);
     });
 
-    it("should fail when the first param is not the wallet ", async () => {
+    it("should fail when the first param is not the wallet", async () => {
       const params = [owner, 4];
       await truffleAssert.reverts(
         manager.relay(testFeature, "setIntOwnerOnly", params, wallet, [owner]), "RM: Target of _data != _wallet",
@@ -280,20 +280,14 @@ contract("RelayerManager", (accounts) => {
     let erc20;
     beforeEach(async () => {
       const decimals = 12; // number of decimal for TOKN contract
-      const tokenRate = new BN(10).pow(new BN(19)).mul(new BN(51)); // 1 TOKN = 0.00051 ETH = 0.00051*10^18 ETH wei => *10^(18-decimals) = 0.00051*10^18 * 10^6 = 0.00051*10^24 = 51*10^19
       erc20 = await ERC20.new([infrastructure], 10000000, decimals); // TOKN contract with 10M tokens (10M TOKN for account[0])
+
+      // Prices stored in registry = price per token * 10^(18-token decimals)
+      const tokenRate = new BN(10).pow(new BN(19)).mul(new BN(51)); // 1 TOKN = 0.00051 ETH = 0.00051*10^18 ETH wei => *10^(18-decimals) = 0.00051*10^18 * 10^6 = 0.00051*10^24 = 51*10^19
       await tokenPriceRegistry.setPriceForTokenList([erc20.address], [tokenRate]);
+
       await limitFeature.setLimitAndDailySpent(wallet.address, 10000000000, 0);
     });
-
-    async function provisionFunds(ethAmount, erc20Amount) {
-      if (ethAmount) {
-        await wallet.send(ethAmount);
-      }
-      if (erc20Amount) {
-        await erc20.transfer(wallet.address, erc20Amount);
-      }
-    }
 
     async function callAndRefund({ refundToken }) {
       const relayParams = [
@@ -309,66 +303,67 @@ contract("RelayerManager", (accounts) => {
       return txReceipt;
     }
 
-    async function setLimitAndDailySpent({ limit, alreadySpent }) {
-      await limitFeature.setLimitAndDailySpent(wallet.address, limit, alreadySpent);
-    }
-
     it("should refund in ETH", async () => {
-      await provisionFunds("100000000000000", 0);
+      await wallet.send("100000000000000");
       const wBalanceStart = await utils.getBalance(wallet.address);
       const rBalanceStart = await utils.getBalance(recipient);
       await callAndRefund({ refundToken: ETH_TOKEN });
       const wBalanceEnd = await utils.getBalance(wallet.address);
       const rBalanceEnd = await utils.getBalance(recipient);
       const refund = wBalanceStart.sub(wBalanceEnd);
-      assert.isTrue(refund.gt(0), "should have refunded ETH");
-      assert.isTrue(refund.eq(rBalanceEnd.sub(rBalanceStart)), "should have refunded the recipient");
+      // should have refunded ETH
+      expect(refund).to.be.gt.BN(0);
+      // should have refunded the recipient
+      expect(refund).to.eq.BN(rBalanceEnd.sub(rBalanceStart));
     });
 
     it("should refund in ERC20", async () => {
-      await provisionFunds(0, "100000000000000");
+      await erc20.transfer(wallet.address, "10000000000");
       const wBalanceStart = await erc20.balanceOf(wallet.address);
       const rBalanceStart = await erc20.balanceOf(recipient);
       await callAndRefund({ refundToken: erc20.address });
       const wBalanceEnd = await erc20.balanceOf(wallet.address);
       const rBalanceEnd = await erc20.balanceOf(recipient);
       const refund = wBalanceStart.sub(wBalanceEnd);
-      assert.isTrue(refund.gt(0), "should have refunded ERC20");
-      assert.isTrue(refund.eq(rBalanceEnd.sub(rBalanceStart)), "should have refunded the recipient");
+      // should have refunded ERC20
+      expect(refund).to.be.gt.BN(0);
+      // should have refunded the recipient
+      expect(refund).to.eq.BN(rBalanceEnd.sub(rBalanceStart));
     });
 
     it("should emit the Refund event", async () => {
-      await provisionFunds("100000000000", 0);
+      await wallet.send("100000000000");
       const txReceipt = await callAndRefund({ refundToken: ETH_TOKEN });
       await utils.hasEvent(txReceipt, relayerManager, "Refund");
     });
 
     it("should fail the transaction when there is not enough ETH for the refund", async () => {
-      await provisionFunds(10, 0);
+      await wallet.send(10);
       await truffleAssert.reverts(callAndRefund({ refundToken: ETH_TOKEN }), "VM: wallet invoke reverted");
     });
 
     it("should fail the transaction when there is not enough ERC20 for the refund", async () => {
-      await provisionFunds(0, 10);
+      await erc20.transfer(wallet.address, 10);
       await truffleAssert.reverts(callAndRefund({ refundToken: erc20.address }), "ERC20: transfer amount exceeds balance");
     });
 
     it("should include the refund in the daily limit", async () => {
-      await provisionFunds("100000000000", 0);
-      await setLimitAndDailySpent({ limit: 1000000000, alreadySpent: 10 });
+      await wallet.send("100000000000");
+      await limitFeature.setLimitAndDailySpent(wallet.address, "1000000000", 10);
       let dailySpent = await limitFeature.getDailySpent(wallet.address);
-      assert.isTrue(dailySpent.toNumber() === 10, "initial daily spent should be 10");
+      expect(dailySpent).to.eq.BN(10);
       await callAndRefund({ refundToken: ETH_TOKEN });
       dailySpent = await limitFeature.getDailySpent(wallet.address);
-      assert.isTrue(dailySpent > 10, "Daily spent should be greater then 10");
+      expect(dailySpent).to.be.gt.BN(10);
     });
 
     it("should refund and reset the daily limit when approved by guardians", async () => {
       // set funds and limit/daily spent
-      await provisionFunds("100000000000", 0);
-      await setLimitAndDailySpent({ limit: 1000000000, alreadySpent: 10 });
+      await wallet.send("100000000000");
+      await limitFeature.setLimitAndDailySpent(wallet.address, 1000000000, 10);
       let dailySpent = await limitFeature.getDailySpent(wallet.address);
-      assert.isTrue(dailySpent.toNumber() === 10, "initial daily spent should be 10");
+      // initial daily spent should be 10
+      expect(dailySpent).to.eq.BN(10);
       const rBalanceStart = await utils.getBalance(recipient);
       // add a guardian
       await guardianManager.addGuardian(wallet.address, guardian, { from: owner });
@@ -377,9 +372,10 @@ contract("RelayerManager", (accounts) => {
       await manager.relay(approvedTransfer, "transferToken", params, wallet, [owner, guardian]);
 
       dailySpent = await limitFeature.getDailySpent(wallet.address);
-      assert.isTrue(dailySpent.toNumber() === 0, "daily spent should be reset");
+      // daily spent should be reset
+      expect(dailySpent).to.be.zero;
       const rBalanceEnd = await utils.getBalance(recipient);
-      assert.isTrue(rBalanceEnd.gt(rBalanceStart), "should have refunded the recipient");
+      expect(rBalanceEnd).to.be.gt.BN(rBalanceStart);
     });
 
     it("should fail if required signatures is 0 and OwnerRequirement is not Anyone", async () => {
@@ -389,10 +385,10 @@ contract("RelayerManager", (accounts) => {
     });
 
     it("should fail the transaction when the refund is over the daily limit", async () => {
-      await provisionFunds("100000000000", 0);
-      await setLimitAndDailySpent({ limit: 1000000000, alreadySpent: 999999990 });
+      await wallet.send("100000000000");
+      await limitFeature.setLimitAndDailySpent(wallet.address, 1000000000, 999999990);
       const dailySpent = await limitFeature.getDailySpent(wallet.address);
-      assert.isTrue(dailySpent.toNumber() === 999999990, "initial daily spent should be 999999990");
+      expect(dailySpent).to.eq.BN(999999990);
       await truffleAssert.reverts(callAndRefund({ refundToken: ETH_TOKEN }), "RM: refund is above daily limit");
     });
   });

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -81,7 +81,7 @@ contract("RelayerManager", (accounts) => {
       limitStorage.address,
       tokenPriceRegistry.address,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
   });
 
   beforeEach(async () => {

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -296,7 +296,7 @@ contract("RelayerManager", (accounts) => {
         [wallet.address, 2],
         wallet,
         [owner],
-        10,
+        10000,
         refundToken,
         recipient];
       const txReceipt = await manager.relay(...relayParams);
@@ -349,7 +349,7 @@ contract("RelayerManager", (accounts) => {
 
     it("should include the refund in the daily limit", async () => {
       await wallet.send("100000000000");
-      await limitFeature.setLimitAndDailySpent(wallet.address, "1000000000", 10);
+      await limitFeature.setLimitAndDailySpent(wallet.address, "100000000000000000", 10);
       let dailySpent = await limitFeature.getDailySpent(wallet.address);
       expect(dailySpent).to.eq.BN(10);
       await callAndRefund({ refundToken: ETH_TOKEN });

--- a/test/simpleUpgrader.js
+++ b/test/simpleUpgrader.js
@@ -144,7 +144,7 @@ contract("SimpleUpgrader", (accounts) => {
     async function testUpgradeModule({ relayed, modulesToAdd = (moduleV2) => [moduleV2] }) {
       // create module V1
       const { module: moduleV1, relayer: relayerV1 } = await deployTestModule();
-      manager.setRelayerManager(relayerV1);
+      await manager.setRelayerManager(relayerV1);
       // register module V1
       await registry.registerModule(moduleV1.address, formatBytes32String("V1"));
       // create wallet with module V1 and relayer feature
@@ -260,7 +260,7 @@ contract("SimpleUpgrader", (accounts) => {
         ethers.constants.AddressZero,
         ethers.constants.AddressZero,
         versionManager.address);
-      manager.setRelayerManager(relayerManager);
+      await manager.setRelayerManager(relayerManager);
 
       // Setup the wallet with the initial set of modules
       await versionManager.addVersion([

--- a/test/tokenExchanger.js
+++ b/test/tokenExchanger.js
@@ -106,7 +106,7 @@ contract("TokenExchanger", (accounts) => {
       ethers.constants.AddressZero,
       versionManager.address,
     );
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     // Deploy test tokens
     tokenA = await ERC20.new([infrastructure], web3.utils.toWei("1000"), DECIMALS);

--- a/test/transferManager.js
+++ b/test/transferManager.js
@@ -128,7 +128,7 @@ contract("TransferManager", (accounts) => {
       limitStorage.address,
       tokenPriceRegistry.address,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     await versionManager.addVersion([transferManager.address, relayerManager.address], [transferManager.address]);
   });

--- a/test/upgraderToVersionManager.js
+++ b/test/upgraderToVersionManager.js
@@ -99,7 +99,7 @@ contract("UpgraderToVersionManager", (accounts) => {
       limitStorage.address,
       ethers.constants.AddressZero,
       versionManager.address);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
     await versionManager.addVersion([transferManager.address, relayerManager.address], [transferManager.address]);
   });
 

--- a/test/versionManager.js
+++ b/test/versionManager.js
@@ -64,7 +64,7 @@ contract("VersionManager", (accounts) => {
       versionManager.address,
       42);
     await versionManager.addVersion([guardianManager.address, relayerManager.address, testFeature.address], []);
-    manager.setRelayerManager(relayerManager);
+    await manager.setRelayerManager(relayerManager);
 
     const proxy = await Proxy.new(walletImplementation.address);
     wallet = await BaseWallet.at(proxy.address);

--- a/truffle-config.base.js
+++ b/truffle-config.base.js
@@ -56,7 +56,6 @@ module.exports = {
       host: "127.0.0.1", // Localhost (default: none)
       port: 8545, // Standard Ethereum port (default: none)
       network_id: "1597649375983",
-      gas: 20700000
     },
 
     test: {
@@ -122,7 +121,7 @@ module.exports = {
   mocha: {
     useColors: true,
     timeout: 1000000,
-    reporter: "eth-gas-reporter",
+    reporter: "spec",
     reporterOptions: {
       currency: "USD",
       onlyCalledMethods: true,

--- a/truffle-config.base.js
+++ b/truffle-config.base.js
@@ -121,7 +121,7 @@ module.exports = {
   mocha: {
     useColors: true,
     timeout: 1000000,
-    reporter: "spec",
+    reporter: "eth-gas-reporter",
     reporterOptions: {
       currency: "USD",
       onlyCalledMethods: true,

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -8,14 +8,12 @@ class RelayManager {
   }
 
   async relay(_module, _method, _params, _wallet, _signers,
-    _relayerAccount,
-    _estimate = false,
     _gasLimit = 1,
     _nonce,
     _gasPrice = 0,
     _refundToken = ETH_TOKEN,
     _refundAddress = ethers.constants.AddressZero) {
-    const relayerAccount = _relayerAccount || await utils.getAccount(9);
+    const relayerAccount = await utils.getAccount(9);
     const nonce = _nonce || await utils.getNonceForRelay();
     const methodData = _module.contract.methods[_method](..._params).encodeABI();
     const chainId = await utils.getChainId();

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -33,7 +33,7 @@ class RelayManager {
       _refundAddress,
     );
 
-    const gasEstimate = await this.relayerManager.estimate.execute(
+    const gasEstimate = await this.relayerManager.execute.estimateGas(
       _wallet.address,
       _module.address,
       methodData,

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -111,7 +111,6 @@ class RelayManager {
     + 10000 * number of signatures (validateSignatures call, should best be estimated but this is also close enough)
     + Function call estimate
     + 40000 / 30000 refund cost for 1 signatures and >1 signatures respectively
-    + 2131  (TransactionExecuted event log)
 
     Ignoring multiplication and comparisson as that is <10 gas per operation
   */
@@ -158,8 +157,8 @@ class RelayManager {
       }
     }
 
-    // gasLimit = 1856 + [0,1000,4800] + 2052 + 45144 + (10000 * _signers.length) + gasEstimateFeatureCall + [30000,40000] + 2131
-    const gasLimit = 51183 + requiredSigsGas + (10000 * _signers.length) + gasEstimateFeatureCall + refundGas;
+    // gasLimit = 1856 + [0,1000,4800] + 2052 + 45144 + (10000 * _signers.length) + gasEstimateFeatureCall + [30000,40000]
+    const gasLimit = 49052 + requiredSigsGas + (10000 * _signers.length) + gasEstimateFeatureCall + refundGas;
     return gasLimit;
   }
 

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -26,7 +26,7 @@ class RelayManager {
     const chainId = await utils.getChainId();
     const methodData = _module.contract.methods[_method](..._params).encodeABI();
 
-    const gasLimit = await this.getGasLimitRefund(_module, _method, _params, _wallet, _signers, _gasPrice);
+    const gasLimit = await this.getGasLimitRefund(_module, _method, _params, _wallet, _signers, _gasPrice, _refundToken);
     // Uncomment when debugging gas limits
     // await this.debugGasLimits(_module, _method, _params, _wallet, _signers);
 
@@ -79,7 +79,7 @@ class RelayManager {
       + 16 * non-empty calldata bytes
       + 4 * empty calldata bytes
     */
-    const gas = gasLimit + 21000 + nonZeros * 16 + zeros * 4 + 50000;
+    const gas = gasLimit + 21000 + nonZeros * 16 + zeros * 4;
 
     const tx = await this.relayerManager.execute(
       _wallet.address,
@@ -116,7 +116,7 @@ class RelayManager {
 
     Ignoring multiplication and comparisson as that is <10 gas per operation
   */
-  async getGasLimitRefund(_module, _method, _params, _wallet, _signers, _gasPrice) {
+  async getGasLimitRefund(_module, _method, _params, _wallet, _signers, _gasPrice, _refundToken) {
     let requiredSigsGas = 0;
     const { contractName } = _module.constructor;
     if (contractName === "ApprovedTransfer" || contractName === "RecoveryManager") {
@@ -150,6 +150,12 @@ class RelayManager {
         refundGas = 30000;
       } else {
         refundGas = 40000;
+      }
+
+      // If the refund is with a token, add transfer cost.
+      // We are using a simple ERC20 transfer cost, however this varies by supported token, e.g. ZRX, BAT, REP, DAI, USDC, or USDT
+      if (_refundToken !== ETH_TOKEN) {
+        refundGas += 30000;
       }
     }
 

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -1,10 +1,16 @@
+/* global artifacts */
 const ethers = require("ethers");
 const { ETH_TOKEN } = require("./utilities.js");
 const utils = require("./utilities.js");
 
+const IGuardianStorage = artifacts.require("IGuardianStorage");
+const IFeature = artifacts.require("IFeature");
+
 class RelayManager {
-  setRelayerManager(relayerManager) {
+  async setRelayerManager(relayerManager) {
     this.relayerManager = relayerManager;
+    const guardianStorageAddress = await relayerManager.guardianStorage();
+    this.guardianStorage = await IGuardianStorage.at(guardianStorageAddress);
   }
 
   // Relays without refund by default, unless the gasPrice is explicitely set to be >0
@@ -14,10 +20,12 @@ class RelayManager {
     _refundAddress = ethers.constants.AddressZero) {
     const relayerAccount = await utils.getAccount(9);
     const nonce = await utils.getNonceForRelay();
-
-    const methodData = _module.contract.methods[_method](..._params).encodeABI();
     const chainId = await utils.getChainId();
-    const _gasLimit = 2000000;
+    const methodData = _module.contract.methods[_method](..._params).encodeABI();
+
+    const gasLimit = await this.getGasLimitRefund(_module, _method, _params, _signers);
+    // Uncomment when debugging gas limits
+    // await this.debugGasLimits(_module, _method, _params, _wallet, _signers);
 
     const signatures = await utils.signOffchain(
       _signers,
@@ -28,28 +36,35 @@ class RelayManager {
       chainId,
       nonce,
       _gasPrice,
-      _gasLimit,
+      gasLimit,
       _refundToken,
       _refundAddress,
     );
 
-    const gasEstimate = await this.relayerManager.execute.estimateGas(
+    const executeData = this.relayerManager.contract.methods.execute(
       _wallet.address,
       _module.address,
       methodData,
       nonce,
       signatures,
       _gasPrice,
-      _gasLimit,
+      gasLimit,
       _refundToken,
-      _refundAddress,
-      { gasPrice: _gasPrice },
-    );
+      _refundAddress).encodeABI();
 
-    console.log("method", _method);
-    console.log("gasEstimate", gasEstimate);
+    // Get the number of zero and non-zero bytes in the relayer.execute calldata
+    const nonZerosString = executeData.toString().slice(2).replace(/0/g, "");
+    const nonZeros = nonZerosString.length;
+    const zeros = executeData.length - nonZeros;
 
-    const gas = _gasLimit * 1.1;
+    /* Calculation used by the back end to relay transactions
+      gasLimit =
+      + 21k (base transaction)
+      + 16 * non-empty calldata bytes
+      + 4 * empty calldata bytes
+    */
+    const gas = gasLimit + 21000 + nonZeros * 16 + zeros * 4;
+
     const tx = await this.relayerManager.execute(
       _wallet.address,
       _module.address,
@@ -57,18 +72,97 @@ class RelayManager {
       nonce,
       signatures,
       _gasPrice,
-      _gasLimit,
+      gasLimit,
       _refundToken,
       _refundAddress,
       { gas, gasPrice: _gasPrice, from: relayerAccount },
     );
 
-    console.log("gasUsed    ", tx.receipt.gasUsed);
+    console.log("gasLimit", gasLimit);
+    console.log("gas sent", gas);
+    console.log("gas used", tx.receipt.gasUsed);
+    console.log("ratio", gas / tx.receipt.gasUsed);
 
-    if (gasEstimate < tx.receipt.gasUsed) {
-      console.log("INSUFFICIENT GAS ESTIMATED");
-    }
     return tx.receipt;
+  }
+
+  /* Returns the gas limit to use as gasLimit parameter in execute function
+    + 1500 (gasleft() check)
+    + 1856  (isFeatureAuthorisedInVersionManager check)
+    + 0 / 1000 / 5000 based on which contract implements getRequiredSignatures()
+    + 2052 (getSignhash call)
+    + 45144 (checkAndUpdateUniqueness call)
+    + 9500 * number of signatures (validateSignatures call, should best be estimated but this is also close enough)
+    + Function call estimate
+    + 2131  (TransactionExecuted event log)
+
+    Ignoring multiplication and comparisson as that is <10 gas per operation
+  */
+  async getGasLimitRefund(_module, _method, _params, _signers) {
+    let requiredSigsGas = 0;
+    const { contractName } = _module.constructor;
+    if (contractName === "ApprovedTransfer" || contractName === "RecoveryManager") {
+      requiredSigsGas = 5000;
+    } else if (contractName === "GuardianManager") {
+      requiredSigsGas = 1000;
+    }
+
+    let gasEstimateFeatureCall = 0;
+    try {
+      gasEstimateFeatureCall = await _module.contract.methods[_method](..._params).estimateGas({ from: this.relayerManager.address });
+      gasEstimateFeatureCall -= 21000;
+    } finally {
+      // When we can't estimate the inner feature call correctly, set this to some large number
+      // This only happens for the following tests atm:
+      // approvedTransfer should revert when target contract is an authorised module
+      // simpleUpgrader should not upgrade to 0 module (relayed tx)
+      // nftTransfer should allow safe NFT transfer from wallet1 to wallet2 (relayed)
+      if (gasEstimateFeatureCall <= 0) {
+        gasEstimateFeatureCall = 90000;
+      }
+    }
+
+    const gasLimit = 1500 + 1856 + requiredSigsGas + 2052 + 45144 + (9500 * _signers.length) + gasEstimateFeatureCall + 2131;
+    return gasLimit;
+  }
+
+  async debugGasLimits(_module, _method, _params, _wallet, _signers) {
+    let requiredSigsGas = 0;
+    try {
+      // Get the owner signature requirements
+      const feature = await IFeature.at(_module.address);
+      const methodData = _module.contract.methods[_method](..._params).encodeABI();
+      requiredSigsGas = await feature.getRequiredSignatures.estimateGas(_wallet.address, methodData);
+      requiredSigsGas -= 21000;
+    } catch (err) {
+      console.log("ERROR", err);
+    }
+
+    let ownerSigner = 0;
+    let eoaSigners = 0;
+    let contractSigners = 0;
+    const walletOwner = await _wallet.owner();
+
+    for (let index = 0; index < _signers.length; index += 1) {
+      const signer = _signers[index];
+      const isGuardian = await this.guardianStorage.isGuardian(_wallet.address, signer);
+      if (signer === walletOwner) {
+        ownerSigner += 1;
+      } else if (isGuardian) {
+        eoaSigners += 1;
+      } else {
+        // For simplicity, assume if it's not the owner or an EOA guardian then it's a smart contract guardian.
+        contractSigners += 1;
+      }
+    }
+
+    console.log("method", _method);
+    console.log("number of signers", _signers.length);
+    console.log("ownerSigner", ownerSigner);
+    console.log("eoaSigners", eoaSigners);
+    console.log("contractSigners", contractSigners);
+
+    console.log("requiredSigsGas", requiredSigsGas);
   }
 }
 

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -165,8 +165,9 @@ class RelayManager {
       }
     }
 
-    // gasLimit = 1856 + [0,1000,4800] + 2052 + nonceCheckGas + (10000 * _signers.length) + gasEstimateFeatureCall + [30000,40000]
+    // gasLimit = 1856 + [0,1000,4800] + 2052 + nonceCheckGas + (10000 * _signers.length) + gasEstimateFeatureCall + [40000,30000]
     const gasLimit = 3908 + requiredSigsGas + nonceCheckGas + (10000 * _signers.length) + gasEstimateFeatureCall + refundGas;
+    // [50108, 51108, 60908] + (10000 * _signers.length) + gasEstimateFeatureCall
     return gasLimit;
   }
 

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -104,9 +104,8 @@ class RelayManager {
   }
 
   /* Returns the gas limit to use as gasLimit parameter in execute function
-    + 1500 (gasleft() check)
     + 1856  (isFeatureAuthorisedInVersionManager check)
-    + 0 / 1000 / 5000 based on which contract implements getRequiredSignatures()
+    + 0 / 1000 / 4800 based on which contract implements getRequiredSignatures()
     + 2052 (getSignHash call)
     + 45144 (checkAndUpdateUniqueness call)
     + 10000 * number of signatures (validateSignatures call, should best be estimated but this is also close enough)
@@ -120,7 +119,7 @@ class RelayManager {
     let requiredSigsGas = 0;
     const { contractName } = _module.constructor;
     if (contractName === "ApprovedTransfer" || contractName === "RecoveryManager") {
-      requiredSigsGas = 5000;
+      requiredSigsGas = 4800;
     } else if (contractName === "GuardianManager") {
       requiredSigsGas = 1000;
     }
@@ -159,7 +158,7 @@ class RelayManager {
       }
     }
 
-    // gasLimit = 1856 + [0,1000,5000] + 2052 + 45144 + (10000 * _signers.length) + gasEstimateFeatureCall + [30000,40000] + 2131
+    // gasLimit = 1856 + [0,1000,4800] + 2052 + 45144 + (10000 * _signers.length) + gasEstimateFeatureCall + [30000,40000] + 2131
     const gasLimit = 51183 + requiredSigsGas + (10000 * _signers.length) + gasEstimateFeatureCall + refundGas;
     return gasLimit;
   }

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -79,7 +79,7 @@ class RelayManager {
       + 16 * non-empty calldata bytes
       + 4 * empty calldata bytes
     */
-    const gas = gasLimit + 21000 + nonZeros * 16 + zeros * 4;
+    const gas = gasLimit + 21000 + nonZeros * 16 + zeros * 4 + 50000;
 
     const tx = await this.relayerManager.execute(
       _wallet.address,
@@ -123,6 +123,14 @@ class RelayManager {
       requiredSigsGas = 1000;
     }
 
+    // Estimate cost of checkAndUpdateUniqueness call
+    let nonceCheckGas = 0;
+    if (_signers.length === 1) {
+      nonceCheckGas = 6200;
+    } else if (_signers.length > 1) {
+      nonceCheckGas = 22200;
+    }
+
     let gasEstimateFeatureCall = 0;
     try {
       gasEstimateFeatureCall = await _module.contract.methods[_method](..._params).estimateGas({ from: this.relayerManager.address });
@@ -157,8 +165,8 @@ class RelayManager {
       }
     }
 
-    // gasLimit = 1856 + [0,1000,4800] + 2052 + 45144 + (10000 * _signers.length) + gasEstimateFeatureCall + [30000,40000]
-    const gasLimit = 49052 + requiredSigsGas + (10000 * _signers.length) + gasEstimateFeatureCall + refundGas;
+    // gasLimit = 1856 + [0,1000,4800] + 2052 + nonceCheckGas + (10000 * _signers.length) + gasEstimateFeatureCall + [30000,40000]
+    const gasLimit = 3908 + requiredSigsGas + nonceCheckGas + (10000 * _signers.length) + gasEstimateFeatureCall + refundGas;
     return gasLimit;
   }
 

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -109,8 +109,9 @@ class RelayManager {
     + 0 / 1000 / 5000 based on which contract implements getRequiredSignatures()
     + 2052 (getSignHash call)
     + 45144 (checkAndUpdateUniqueness call)
-    + 9500 * number of signatures (validateSignatures call, should best be estimated but this is also close enough)
+    + 10000 * number of signatures (validateSignatures call, should best be estimated but this is also close enough)
     + Function call estimate
+    + 40000 / 30000 refund cost for 1 signatures and >1 signatures respectively
     + 2131  (TransactionExecuted event log)
 
     Ignoring multiplication and comparisson as that is <10 gas per operation
@@ -152,7 +153,8 @@ class RelayManager {
       }
     }
 
-    const gasLimit = 1500 + 1856 + requiredSigsGas + 2052 + 45144 + (9500 * _signers.length) + gasEstimateFeatureCall + refundGas + 2131;
+    // gasLimit = 1856 + [0,1000,5000] + 2052 + 45144 + (10000 * _signers.length) + gasEstimateFeatureCall + [30000,40000] + 2131
+    const gasLimit = 51183 + requiredSigsGas + (10000 * _signers.length) + gasEstimateFeatureCall + refundGas;
     return gasLimit;
   }
 

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -142,7 +142,7 @@ class RelayManager {
       // simpleUpgrader should not upgrade to 0 module (relayed tx)
       // nftTransfer should allow safe NFT transfer from wallet1 to wallet2 (relayed)
       if (gasEstimateFeatureCall <= 0) {
-        gasEstimateFeatureCall = 80000;
+        gasEstimateFeatureCall = 140000;
       }
     }
 

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -126,6 +126,9 @@ class RelayManager {
     let nonceCheckGas = 0;
     if (_signers.length === 1) {
       nonceCheckGas = 6200;
+      // Most calls here are the first for wallet so default to 20K gas extra for a storage slot update
+      // We could check if the wallet nonce is empty before we add this
+      nonceCheckGas += 20000;
     } else if (_signers.length > 1) {
       nonceCheckGas = 22200;
     }

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -94,11 +94,10 @@ class RelayManager {
       { gas, gasPrice: _gasPrice, from: relayerAccount },
     );
 
-    console.log("gasLimit", gasLimit);
-    console.log("_gasLimit", _gasLimit);
-    console.log("gas sent", gas);
-    console.log("gas used", tx.receipt.gasUsed);
-    console.log("ratio", _gasLimit / tx.receipt.gasUsed);
+    // console.log("_gasLimit", _gasLimit);
+    // console.log("gas sent", gas);
+    // console.log("gas used", tx.receipt.gasUsed);
+    // console.log("ratio", _gasLimit / tx.receipt.gasUsed);
 
     return tx.receipt;
   }
@@ -143,7 +142,7 @@ class RelayManager {
       // simpleUpgrader should not upgrade to 0 module (relayed tx)
       // nftTransfer should allow safe NFT transfer from wallet1 to wallet2 (relayed)
       if (gasEstimateFeatureCall <= 0) {
-        gasEstimateFeatureCall = 90000;
+        gasEstimateFeatureCall = 80000;
       }
     }
 

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -103,7 +103,7 @@ class RelayManager {
   }
 
   /* Returns the gas limit to use as gasLimit parameter in execute function
-    + 1856  (isFeatureAuthorisedInVersionManager check)
+    + 5200  (isFeatureAuthorisedInVersionManager check)
     + 0 / 1000 / 4800 based on which contract implements getRequiredSignatures()
     + 2052 (getSignHash call)
     + 45144 (checkAndUpdateUniqueness call)
@@ -168,9 +168,9 @@ class RelayManager {
       // }
     }
 
-    // gasLimit = 1856 + [0,1000,4800] + 2052 + nonceCheckGas + (10000 * _signers.length) + gasEstimateFeatureCall + [40000,30000]
-    const gasLimit = 3908 + requiredSigsGas + nonceCheckGas + (10000 * _signers.length) + gasEstimateFeatureCall + refundGas;
-    // [50108, 51108, 60908] + (10000 * _signers.length) + gasEstimateFeatureCall
+    // gasLimit = 5200 + [0,1000,4800] + 2052 + nonceCheckGas + (10000 * _signers.length) + gasEstimateFeatureCall + [40000,30000]
+    const gasLimit = 7252 + requiredSigsGas + nonceCheckGas + (10000 * _signers.length) + gasEstimateFeatureCall + refundGas;
+    // [32452, 33452, 43250] + (10000 * _signers.length) + gasEstimateFeatureCall
     return gasLimit;
   }
 

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -72,7 +72,7 @@ class RelayManager {
       _refundAddress).encodeABI();
 
     // Get the number of zero and non-zero bytes in the relayer.execute calldata
-    const nonZerosString = executeData.toString().slice(2).replace(/0/g, "");
+    const nonZerosString = executeData.toString().slice(2).replace(/00(?=(..)*$)/g, "");
     const nonZeros = nonZerosString.length;
     const zeros = executeData.length - nonZeros;
 


### PR DESCRIPTION
Estimating relayed transactions with refunds logic has two core issues:
1) The `gasLimit` parameter used in the refunds logic depends on the estimate of the overall transaction, yet it is also included in that transaction. This means that essentially users need to sign two transactions, one for estimation and second one with the calculated `gasLimit`. 
2) Due to the refunds logic using a `gasleft()` opcode which depends on the overall gas sent for the transaction, [eth_estimateGas returns bad estimations](https://github.com/trufflesuite/ganache-core/issues/617).  

These have led us to break down the `RelayerManager.exececute()` logic into seperate parts, estimate those individually and use that logic for calculating the `gasLimit` for relayed transactions. This logic is encapsulated in the `relay-manager.js` component used in tests where we've enabled all relayed transactions to use gas estimation. See https://www.notion.so/argenthq/Gastimation-WC-Investments-893edacddfe24678ae6dae803e20bd46 for details on the maths behind this.

To enable further debugging of gas estimations, a `debugGasLimits` function is introduces which can be uncommented to start printing gas estimate and spending information in the `relay-manager.js`
```
    // await this.debugGasLimits(_module, _method, _params, _wallet, _signers);
```

The relayer estimation logic in `relay-manager.relay()` defaults to **_no refunds_** as these affect daily limits, account and contract balances thus skewing test results.  Refunds are tested in isolation in `relayer.js` tests. To enable refunds for a relayed transaction, simply pass in the following additional parameters  `_module, _method, _params, _wallet, _signers` to `relay-manager.relay()`.