### PR TITLE
Fixes to coverage testing and solc-select install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,9 @@ step_setup_solc_select: &step_setup_solc_select
   run:
     name: "Setup solc-select"
     command: |
-      git clone https://github.com/crytic/solc-select.git
-      bash ./solc-select/scripts/install.sh
+      sudo pip3 install solc-select
+      solc-select install 0.5.4
+      solc-select install 0.6.12
 jobs:
   unit-test:
     <<: *job_common
@@ -115,8 +116,6 @@ jobs:
           name: "Check TokenPriceRegistry tokens for ERC20 compliance"
           command:  |
             export PATH=/home/circleci/.solc-select:$PATH
-            echo "export PATH=/home/circleci/.solc-select:$PATH" >> ~/.bashrc
-            solc --version
             npm run validate:erc20
       - run:
           name: "Run slither on infrastructure contracts based on solc 0.5"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "npx truffle test --compile-none",
     "ctest": "npm run compile && npm run test",
     "provision:lib:artefacts": "bash ./scripts/provision_lib_artefacts.sh",
-    "test:coverage": "node scripts/coverage.js && istanbul check-coverage --statements 82 --branches 78 --functions 82 --lines 82",
+    "test:coverage": "COVERAGE=1 node scripts/coverage.js && istanbul check-coverage --statements 82 --branches 78 --functions 82 --lines 82",
     "lint:js": "eslint .",
     "lint:contracts": "npx solhint contracts/**/*.sol && npx solhint contracts/**/**/*.sol",
     "test:deployment": "./scripts/deploy.sh --no-compile development `seq 1 6`",

--- a/utils/relay-manager.js
+++ b/utils/relay-manager.js
@@ -81,10 +81,13 @@ class RelayManager {
       + 21k (base transaction)
       + 16 * non-empty calldata bytes
       + 4 * empty calldata bytes
-      + 50k buffer
+      + 70k buffer
     */
-    const gas = gasLimit + 21000 + nonZeros * 16 + zeros * 4 + 50000;
+    let gas = gasLimit + 21000 + nonZeros * 16 + zeros * 4 + 70000;
 
+    if (process.env.COVERAGE) {
+      gas += 50000;
+    }
     const tx = await this.relayerManager.execute(
       _wallet.address,
       _feature.address,


### PR DESCRIPTION
Fixes to a couple of issues with build:
- Update `solc-select` setup which is now installed via a python package
- Increase gas buffer for relayed transactions as it's causing some of the heavier on gas coverage tests to fail, see [sample failed build](https://app.circleci.com/pipelines/github/argentlabs/argent-contracts/1675/workflows/4b9a8d52-7e15-4b17-8404-3ce67a8c7385/jobs/2007)