### PR TITLE
Extended WalletCreated event with refund info

### DIFF
--- a/contracts/infrastructure/WalletFactory.sol
+++ b/contracts/infrastructure/WalletFactory.sol
@@ -47,8 +47,7 @@ contract WalletFactory is Owned, Managed {
 
     event ModuleRegistryChanged(address addr);
     event RefundAddressChanged(address addr);
-    event WalletCreated(address indexed wallet, address indexed owner, address indexed guardian);
-    event WalletFeeRefund(address indexed wallet, address indexed refundAddress, address refundToken, uint256 refundAmount);
+    event WalletCreated(address indexed wallet, address indexed owner, address indexed guardian, address refundToken, uint256 refundAmount);
 
     // *************** Constructor ********************** //
 
@@ -102,6 +101,10 @@ contract WalletFactory is Owned, Managed {
         }
         // remove the factory from the authorised modules
         BaseWallet(wallet).authoriseModule(address(this), false);
+
+        // emit event
+        emit WalletCreated(wallet, _owner, _guardian, _refundToken, _refundAmount);
+
         return wallet;
     }
 
@@ -193,9 +196,6 @@ contract WalletFactory is Owned, Managed {
 
         // upgrade the wallet
         IVersionManager(_versionManager).upgradeWallet(address(_wallet), _version);
-
-        // emit event
-        emit WalletCreated(address(_wallet), _owner, _guardian);
     }
 
     /**
@@ -257,8 +257,6 @@ contract WalletFactory is Owned, Managed {
                 }
             }
         }
-
-        emit WalletFeeRefund(_wallet, refundAddress, _refundToken, _refundAmount);
     }
 
     /**

--- a/contracts/infrastructure/WalletFactory.sol
+++ b/contracts/infrastructure/WalletFactory.sol
@@ -48,6 +48,7 @@ contract WalletFactory is Owned, Managed {
     event ModuleRegistryChanged(address addr);
     event RefundAddressChanged(address addr);
     event WalletCreated(address indexed wallet, address indexed owner, address indexed guardian);
+    event WalletFeeRefund(address indexed wallet, address indexed refundAddress, address refundToken, uint256 refundAmount);
 
     // *************** Constructor ********************** //
 
@@ -256,6 +257,8 @@ contract WalletFactory is Owned, Managed {
                 }
             }
         }
+
+        emit WalletFeeRefund(_wallet, refundAddress, _refundToken, _refundAmount);
     }
 
     /**

--- a/test/factory.js
+++ b/test/factory.js
@@ -240,7 +240,7 @@ contract("WalletFactory", (accounts) => {
       const tx = await factory.createCounterfactualWallet(
         owner, versionManager.address, guardian, salt, 1, refundAmount, ETH_TOKEN, ownerSig,
       );
-      const event = await utils.getEvent(tx.receipt, factory, "WalletFeeRefund");
+      const event = await utils.getEvent(tx.receipt, factory, "WalletCreated");
       const walletAddr = event.args.wallet;
       const balanceAfter = await utils.getBalance(refundAddress);
       // we test that the wallet is at the correct address
@@ -248,7 +248,6 @@ contract("WalletFactory", (accounts) => {
       // we test that the creation was refunded
       assert.equal(balanceAfter.sub(balanceBefore).toNumber(), refundAmount, "should have refunded in ETH");
 
-      assert.equal(event.args.refundAddress, refundAddress);
       assert.equal(event.args.refundToken, ETH_TOKEN);
       assert.equal(event.args.refundAmount, refundAmount);
     });
@@ -267,7 +266,7 @@ contract("WalletFactory", (accounts) => {
       const tx = await factory.createCounterfactualWallet(
         owner, versionManager.address, guardian, salt, 1, refundAmount, token.address, ownerSig,
       );
-      const event = await utils.getEvent(tx.receipt, factory, "WalletFeeRefund");
+      const event = await utils.getEvent(tx.receipt, factory, "WalletCreated");
       const walletAddr = event.args.wallet;
 
       const balanceAfter = await token.balanceOf(refundAddress);
@@ -276,7 +275,6 @@ contract("WalletFactory", (accounts) => {
       // we test that the creation was refunded
       assert.equal(balanceAfter.sub(balanceBefore).toNumber(), refundAmount, "should have refunded in token");
 
-      assert.equal(event.args.refundAddress, refundAddress);
       assert.equal(event.args.refundToken, token.address);
       assert.equal(event.args.refundAmount, refundAmount);
     });

--- a/test/factory.js
+++ b/test/factory.js
@@ -281,7 +281,7 @@ contract("WalletFactory", (accounts) => {
       assert.equal(event.args.refundAmount, refundAmount);
     });
 
-    it("should create but not refund when an invalid signature is provided", async () => {
+    it("should create but not refund when an invalid refund amount is provided", async () => {
       const refundAmount = 1000;
       const salt = utils.generateSaltValue();
       // we get the future address
@@ -304,7 +304,7 @@ contract("WalletFactory", (accounts) => {
       assert.equal(balanceAfter.sub(balanceBefore), 0, "should not have refunded");
     });
 
-    it("should create but not refund when an invalid refund amount is provided", async () => {
+    it("should create but not refund when an invalid signature is provided", async () => {
       const refundAmount = 1000;
       const salt = utils.generateSaltValue();
       // we get the future address
@@ -347,10 +347,15 @@ contract("WalletFactory", (accounts) => {
     it("should fail to create when there is not enough for the refund", async () => {
       const refundAmount = 1000;
       const salt = utils.generateSaltValue();
+
+      const futureAddr = await factory.getAddressForCounterfactualWallet(owner, versionManager.address, guardian, salt, 1);
+      // Send less ETH than the refund
+      await web3.eth.sendTransaction({ from: infrastructure, to: futureAddr, value: 900 });
+
       // we get the owner signature for a refund
       const ownerSig = await signRefund(refundAmount, ETH_TOKEN, owner);
       await truffleAssert.reverts(
-        factory.createCounterfactualWallet(owner, versionManager.address, ZERO_ADDRESS, salt, 1, refundAmount, ETH_TOKEN, ownerSig),
+        factory.createCounterfactualWallet(owner, versionManager.address, guardian, salt, 1, refundAmount, ETH_TOKEN, ownerSig)
       );
     });
 

--- a/utils/abi-uploader.js
+++ b/utils/abi-uploader.js
@@ -12,7 +12,7 @@ class ABIUploaderS3 {
   }
 
   async upload(contractWrapper, folder) {
-    const { contractName } = contractWrapper.contract;
+    const { contractName } = contractWrapper.constructor;
     const filename = contractWrapper.address;
 
     console.log(`Uploading ${contractName} ABI to AWS...`);
@@ -30,13 +30,13 @@ class ABIUploaderS3 {
     }).promise();
 
     await s3.putObject({
-      Body: JSON.stringify(contractWrapper.contract),
+      Body: JSON.stringify(contractWrapper.constructor._json),
       Bucket: this._bucket,
       Key: `${S3_BUCKET_FOLDER_BUILD}/${folder}/${contractName}/${filename}.json`,
     }).promise();
 
     await s3.putObject({
-      Body: JSON.stringify(contractWrapper.contract),
+      Body: JSON.stringify(contractWrapper.constructor._json),
       Bucket: this._bucket,
       Key: `${S3_BUCKET_FOLDER_BUILD}/ALL/${filename}.json`,
     }).promise();


### PR DESCRIPTION
Extend the `WalletCreated` event to include `refundToken` and `refundAmount` information to help clients with refund cost calculation.

Fixes to the `abi-uploader` to use for the truffle contract syntax.

Additionally there were some inconsistencies with wallet factory tests which were fixed.