### PR TITLE
fixing broken test and reducing bytecode size

### DIFF
--- a/contracts/modules/ArgentModule.sol
+++ b/contracts/modules/ArgentModule.sol
@@ -90,7 +90,7 @@ contract ArgentModule is BaseModule, RelayerManager, SecurityManager, Transactio
         }
         if (methodId == SecurityManager.executeRecovery.selector) {
             // majority of guardians
-            uint numberOfSignaturesRequired = Utils.ceil(guardianStorage.guardianCount(_wallet), 2);
+            uint numberOfSignaturesRequired = _majorityOfGuardians(_wallet);
             require(numberOfSignaturesRequired > 0, "SM: no guardians set on wallet");
             return (numberOfSignaturesRequired, OwnerSignature.Disallowed);
         }
@@ -105,7 +105,7 @@ contract ArgentModule is BaseModule, RelayerManager, SecurityManager, Transactio
             methodId == SecurityManager.transferOwnership.selector)
         {
             // owner + majority of guardians
-            uint majorityGuardians = Utils.ceil(guardianStorage.guardianCount(_wallet), 2);
+            uint majorityGuardians = _majorityOfGuardians(_wallet);
             uint numberOfSignaturesRequired = SafeMath.add(majorityGuardians, 1);
             return (numberOfSignaturesRequired, OwnerSignature.Required);
         }
@@ -121,5 +121,9 @@ contract ArgentModule is BaseModule, RelayerManager, SecurityManager, Transactio
             return (1, OwnerSignature.Disallowed);
         }
         revert("SM: unknown method");
+    }
+
+    function _majorityOfGuardians(address _wallet) internal view returns (uint) {
+        return Utils.ceil(guardianStorage.guardianCount(_wallet), 2);
     }
 }

--- a/contracts/modules/SecurityManager.sol
+++ b/contracts/modules/SecurityManager.sol
@@ -231,7 +231,7 @@ abstract contract SecurityManager is BaseModule {
      * @param _guardian The guardian to add.
      */
     function addGuardian(address _wallet, address _guardian) external onlyWalletOwnerOrSelf(_wallet) onlyWhenUnlocked(_wallet) {
-        require(!_isOwner(_wallet, _guardian), "SM: _guardian cannot be owner");
+        require(!_isOwner(_wallet, _guardian), "SM: guardian cannot be owner");
         require(!isGuardian(_wallet, _guardian), "SM: duplicate guardian");
         // Guardians must either be an EOA or a contract with an owner()
         // method that returns an address with a 5000 gas stipend.
@@ -370,8 +370,8 @@ abstract contract SecurityManager is BaseModule {
     // *************** Internal Functions ********************* //
 
     function validateNewOwner(address _wallet, address _newOwner) internal view {
-        require(_newOwner != address(0), "SM: _newOwner cannot be null");
-        require(!isGuardian(_wallet, _newOwner), "SM: _newOwner is guardian");
+        require(_newOwner != address(0), "SM: new owner cannot be null");
+        require(!isGuardian(_wallet, _newOwner), "SM: new owner cannot be guardian");
     }
 
     function _setLock(address _wallet, uint256 _releaseAfter, bytes4 _locker) internal {

--- a/contracts/modules/SecurityManager.sol
+++ b/contracts/modules/SecurityManager.sol
@@ -73,7 +73,7 @@ abstract contract SecurityManager is BaseModule {
      * @notice Throws if there is no ongoing recovery procedure.
      */
     modifier onlyWhenRecovery(address _wallet) {
-        require(recoveryConfigs[_wallet].executeAfter > 0, "RM: there must be an ongoing recovery");
+        require(recoveryConfigs[_wallet].executeAfter > 0, "RM: no ongoing recovery");
         _;
     }
 
@@ -81,7 +81,7 @@ abstract contract SecurityManager is BaseModule {
      * @notice Throws if there is an ongoing recovery procedure.
      */
     modifier notWhenRecovery(address _wallet) {
-        require(recoveryConfigs[_wallet].executeAfter == 0, "RM: there cannot be an ongoing recovery");
+        require(recoveryConfigs[_wallet].executeAfter == 0, "RM: ongoing recovery");
         _;
     }
 
@@ -89,7 +89,7 @@ abstract contract SecurityManager is BaseModule {
      * @notice Throws if the caller is not a guardian for the wallet.
      */
     modifier onlyGuardianOrSelf(address _wallet) {
-        require(_isSelf(msg.sender) || isGuardian(_wallet, msg.sender), "SM: must be guardian or feature");
+        require(_isSelf(msg.sender) || isGuardian(_wallet, msg.sender), "SM: must be guardian/self");
         _;
     }
 
@@ -138,7 +138,7 @@ abstract contract SecurityManager is BaseModule {
      */
     function finalizeRecovery(address _wallet) external onlyWhenRecovery(_wallet) {
         RecoveryConfig storage config = recoveryConfigs[_wallet];
-        require(uint64(block.timestamp) > config.executeAfter, "SM: the recovery period is not over yet");
+        require(uint64(block.timestamp) > config.executeAfter, "SM: ongoing recovery period");
         address recoveryOwner = config.recovery;
         delete recoveryConfigs[_wallet];
 
@@ -154,8 +154,7 @@ abstract contract SecurityManager is BaseModule {
      * @param _wallet The target wallet.
      */
     function cancelRecovery(address _wallet) external onlySelf() onlyWhenRecovery(_wallet) {
-        RecoveryConfig storage config = recoveryConfigs[_wallet];
-        address recoveryOwner = config.recovery;
+        address recoveryOwner = recoveryConfigs[_wallet].recovery;
         delete recoveryConfigs[_wallet];
         _setLock(_wallet, 0, bytes4(0));
 
@@ -232,13 +231,13 @@ abstract contract SecurityManager is BaseModule {
      * @param _guardian The guardian to add.
      */
     function addGuardian(address _wallet, address _guardian) external onlyWalletOwnerOrSelf(_wallet) onlyWhenUnlocked(_wallet) {
-        require(!_isOwner(_wallet, _guardian), "SM: target guardian cannot be owner");
-        require(!isGuardian(_wallet, _guardian), "SM: target is already a guardian");
+        require(!_isOwner(_wallet, _guardian), "SM: _guardian cannot be owner");
+        require(!isGuardian(_wallet, _guardian), "SM: duplicate guardian");
         // Guardians must either be an EOA or a contract with an owner()
         // method that returns an address with a 5000 gas stipend.
         // Note that this test is not meant to be strict and can be bypassed by custom malicious contracts.
         (bool success,) = _guardian.call{gas: 5000}(abi.encodeWithSignature("owner()"));
-        require(success, "SM: guardian must be EOA or implement owner()");
+        require(success, "SM: must be EOA/Argent wallet");
         if (guardianStorage.guardianCount(_wallet) == 0) {
             guardianStorage.addGuardian(_wallet, _guardian);
             emit GuardianAdded(_wallet, _guardian);
@@ -247,7 +246,7 @@ abstract contract SecurityManager is BaseModule {
             GuardianManagerConfig storage config = guardianConfigs[_wallet];
             require(
                 config.pending[id] == 0 || block.timestamp > config.pending[id] + securityWindow,
-                "SM: addition of target as guardian is already pending");
+                "SM: duplicate pending additon");
             config.pending[id] = block.timestamp + securityPeriod;
             emit GuardianAdditionRequested(_wallet, _guardian, block.timestamp + securityPeriod);
         }
@@ -262,9 +261,9 @@ abstract contract SecurityManager is BaseModule {
     function confirmGuardianAddition(address _wallet, address _guardian) external onlyWhenUnlocked(_wallet) {
         bytes32 id = keccak256(abi.encodePacked(_wallet, _guardian, "addition"));
         GuardianManagerConfig storage config = guardianConfigs[_wallet];
-        require(config.pending[id] > 0, "SM: no pending addition as guardian for target");
-        require(config.pending[id] < block.timestamp, "SM: Too early to confirm guardian addition");
-        require(block.timestamp < config.pending[id] + securityWindow, "SM: Too late to confirm guardian addition");
+        require(config.pending[id] > 0, "SM: unknown pending addition");
+        require(config.pending[id] < block.timestamp, "SM: pending addition not over");
+        require(block.timestamp < config.pending[id] + securityWindow, "SM: pending addition expired");
         guardianStorage.addGuardian(_wallet, _guardian);
         emit GuardianAdded(_wallet, _guardian);
         delete config.pending[id];
@@ -278,7 +277,7 @@ abstract contract SecurityManager is BaseModule {
     function cancelGuardianAddition(address _wallet, address _guardian) external onlyWalletOwnerOrSelf(_wallet) onlyWhenUnlocked(_wallet) {
         bytes32 id = keccak256(abi.encodePacked(_wallet, _guardian, "addition"));
         GuardianManagerConfig storage config = guardianConfigs[_wallet];
-        require(config.pending[id] > 0, "SM: no pending addition as guardian for target");
+        require(config.pending[id] > 0, "SM: unknown pending addition");
         delete config.pending[id];
         emit GuardianAdditionCancelled(_wallet, _guardian);
     }
@@ -290,12 +289,12 @@ abstract contract SecurityManager is BaseModule {
      * @param _guardian The guardian to revoke.
      */
     function revokeGuardian(address _wallet, address _guardian) external onlyWalletOwnerOrSelf(_wallet) {
-        require(isGuardian(_wallet, _guardian), "SM: must be an existing guardian");
+        require(isGuardian(_wallet, _guardian), "SM: must be existing guardian");
         bytes32 id = keccak256(abi.encodePacked(_wallet, _guardian, "revokation"));
         GuardianManagerConfig storage config = guardianConfigs[_wallet];
         require(
             config.pending[id] == 0 || block.timestamp > config.pending[id] + securityWindow,
-            "SM: revokation of target as guardian is already pending"); // TODO need to allow if confirmation window passed
+            "SM: duplicate pending revoke"); // TODO need to allow if confirmation window passed
         config.pending[id] = block.timestamp + securityPeriod;
         emit GuardianRevokationRequested(_wallet, _guardian, block.timestamp + securityPeriod);
     }
@@ -309,9 +308,9 @@ abstract contract SecurityManager is BaseModule {
     function confirmGuardianRevokation(address _wallet, address _guardian) external {
         bytes32 id = keccak256(abi.encodePacked(_wallet, _guardian, "revokation"));
         GuardianManagerConfig storage config = guardianConfigs[_wallet];
-        require(config.pending[id] > 0, "SM: no pending guardian revokation for target");
-        require(config.pending[id] < block.timestamp, "SM: Too early to confirm guardian revokation");
-        require(block.timestamp < config.pending[id] + securityWindow, "SM: Too late to confirm guardian revokation");
+        require(config.pending[id] > 0, "SM: unknown pending revoke");
+        require(config.pending[id] < block.timestamp, "SM: pending revoke not over");
+        require(block.timestamp < config.pending[id] + securityWindow, "SM: pending revoke expired");
         guardianStorage.revokeGuardian(_wallet, _guardian);
         emit GuardianRevoked(_wallet, _guardian);
         delete config.pending[id];
@@ -325,7 +324,7 @@ abstract contract SecurityManager is BaseModule {
     function cancelGuardianRevokation(address _wallet, address _guardian) external onlyWalletOwnerOrSelf(_wallet) onlyWhenUnlocked(_wallet) {
         bytes32 id = keccak256(abi.encodePacked(_wallet, _guardian, "revokation"));
         GuardianManagerConfig storage config = guardianConfigs[_wallet];
-        require(config.pending[id] > 0, "SM: no pending guardian revokation for target");
+        require(config.pending[id] > 0, "SM: unknown pending revoke");
         delete config.pending[id];
         emit GuardianRevokationCancelled(_wallet, _guardian);
     }
@@ -371,8 +370,8 @@ abstract contract SecurityManager is BaseModule {
     // *************** Internal Functions ********************* //
 
     function validateNewOwner(address _wallet, address _newOwner) internal view {
-        require(_newOwner != address(0), "SM: new owner address cannot be null");
-        require(!isGuardian(_wallet, _newOwner), "SM: new owner address cannot be a guardian");
+        require(_newOwner != address(0), "SM: _newOwner cannot be null");
+        require(!isGuardian(_wallet, _newOwner), "SM: _newOwner is guardian");
     }
 
     function _setLock(address _wallet, uint256 _releaseAfter, bytes4 _locker) internal {

--- a/contracts/modules/TransactionManager.sol
+++ b/contracts/modules/TransactionManager.sol
@@ -50,7 +50,6 @@ abstract contract TransactionManager is BaseModule {
     event ToggledDappRegistry(address _wallet, bytes32 _registry, bool isEnabled);
     event SessionCreated(address indexed wallet, address sessionKey, uint64 expires);
     event SessionCleared(address indexed wallet, address sessionKey);
-    event ERC1155TokenReceiverEnabled(address indexed _wallet);
 
     // *************** External functions ************************ //
 
@@ -249,7 +248,7 @@ abstract contract TransactionManager is BaseModule {
 
     function recoverSpender(address _wallet, Call calldata _transaction) internal pure returns (address) {
         if (_transaction.isSpenderInData) {
-            require(_transaction.value == 0, "TM: unsecure call with spender in data");
+            require(_transaction.value == 0, "TM: unsecure call");
             // transfer(to, value), transferFrom(wallet, to, value),
             (address first, address second) = abi.decode(_transaction.data[4:], (address, address));
             return first == _wallet ? second : first;

--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -115,7 +115,7 @@ abstract contract BaseModule is IModule {
      * @notice Throws if the sender is not the module itself or the owner of the target wallet.
      */
     modifier onlyWalletOwnerOrSelf(address _wallet) {
-        require(_isSelf(msg.sender) || _isOwner(_wallet, msg.sender), "BM: must be a wallet owner or self");
+        require(_isSelf(msg.sender) || _isOwner(_wallet, msg.sender), "BM: must be wallet owner/self");
         _;
     }
 

--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -42,11 +42,11 @@ abstract contract BaseModule is IModule {
     // The Module Registry
     IModuleRegistry internal registry;
     // The Guardian storage
-    IGuardianStorage internal guardianStorage;
+    IGuardianStorage internal immutable guardianStorage;
     // The Guardian storage
-    ITransferStorage internal userWhitelist;
+    ITransferStorage internal immutable userWhitelist;
     // The Guardian storage
-    IAuthoriser internal authoriser;
+    IAuthoriser internal immutable authoriser;
 
     // The security period
     uint256 internal securityPeriod;

--- a/test/static-calls.js
+++ b/test/static-calls.js
@@ -17,12 +17,12 @@ const BaseWalletV24Contract = require("../build-legacy/v2.4.0/BaseWallet");
 const BaseWalletV24 = TruffleContract(BaseWalletV24Contract);
 
 const Registry = artifacts.require("ModuleRegistry");
-const LockStorage = artifacts.require("LockStorage");
 const TransferStorage = artifacts.require("TransferStorage");
 const GuardianStorage = artifacts.require("GuardianStorage");
 const ArgentModule = artifacts.require("ArgentModule");
 const Authoriser = artifacts.require("DappRegistry");
 const ERC165Tester = artifacts.require("TestContract");
+const UniswapV2Router01 = artifacts.require("DummyUniV2Router");
 
 const utils = require("../utils/utilities.js");
 const { ARGENT_WHITELIST } = require("../utils/utilities.js");
@@ -47,7 +47,6 @@ contract("Static Calls", (accounts) => {
   let signature;
 
   let registry;
-  let lockStorage;
   let transferStorage;
   let guardianStorage;
   let module;
@@ -63,17 +62,18 @@ contract("Static Calls", (accounts) => {
     BaseWalletV24.setProvider(web3.currentProvider);
 
     registry = await Registry.new();
-    lockStorage = await LockStorage.new();
     guardianStorage = await GuardianStorage.new();
     transferStorage = await TransferStorage.new();
     authoriser = await Authoriser.new();
 
+    const uniswapRouter = await UniswapV2Router01.new();
+
     module = await ArgentModule.new(
       registry.address,
-      lockStorage.address,
       guardianStorage.address,
       transferStorage.address,
       authoriser.address,
+      uniswapRouter.address,
       SECURITY_PERIOD,
       SECURITY_WINDOW,
       LOCK_PERIOD,

--- a/truffle-config-modules.js
+++ b/truffle-config-modules.js
@@ -11,7 +11,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 999,
+          runs: 800,
         },
       },
     },

--- a/utils/versions/development/latest.json
+++ b/utils/versions/development/latest.json
@@ -1,1 +1,1 @@
-{"modules":[{"address":"0xaaF0CCef0C0C355Ee764B3d36bcCF257C527269B","name":"ArgentModule"}],"fingerprint":"0xad5d3cb9","version":"1.0.0","createdAt":1614001959}
+{"modules":[{"address":"0x1a8238498Ee9FF5FAb5375B4dD4386a236C22Ba3","name":"ArgentModule"}],"fingerprint":"0x1c13f984","version":"1.0.0","createdAt":1614338578}


### PR DESCRIPTION
This PR fixes a broken test and reduces the size of some reverts strings in `BaseModule`, `SecurityManager` and `TransactionManager` to make sure they fit in `bytes32`.

It also decreases the number of compiler runs from `999` to `800` to reduce the size of the `ArgentModule` bytecode under 24576 bytes.  