### PR TITLE
Revert strings cleanup

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -9,6 +9,6 @@
       "max-line-length": ["error", 150],
       "func-param-name-mixedcase": "error",
       "modifier-name-mixedcase": "error",
-      "reason-string": ["warn", { "maxLength":32 }]
+      "reason-string": ["error", { "maxLength":32 }]
     }
 }

--- a/contracts/infrastructure/WalletFactory.sol
+++ b/contracts/infrastructure/WalletFactory.sol
@@ -50,9 +50,9 @@ contract WalletFactory is Managed {
      */
     constructor(address _walletImplementation, address _guardianStorage, address _refundAddress) public {
         
-        require(_walletImplementation != address(0), "WF: WalletImplementation address not defined");
-        require(_guardianStorage != address(0), "WF: GuardianStorage address not defined");
-        require(_refundAddress != address(0), "WF: refund address not defined");
+        require(_walletImplementation != address(0), "WF: empty wallet implementation");
+        require(_guardianStorage != address(0), "WF: empty guardian storage");
+        require(_refundAddress != address(0), "WF: empty refund address");
         walletImplementation = _walletImplementation;
         guardianStorage = _guardianStorage;
         refundAddress = _refundAddress;
@@ -141,7 +141,7 @@ contract WalletFactory is Managed {
      * @param _refundAddress The address to use for refunds.
      */
     function changeRefundAddress(address _refundAddress) external onlyOwner {
-        require(_refundAddress != address(0), "WF: address cannot be null");
+        require(_refundAddress != address(0), "WF: cannot set to empty");
         refundAddress = _refundAddress;
         emit RefundAddressChanged(_refundAddress);
     }
@@ -199,10 +199,10 @@ contract WalletFactory is Managed {
      * @param _guardian The guardian address
      */
     function validateInputs(address _owner, address[] calldata _modules, address _guardian) internal pure {
-        require(_owner != address(0), "WF: owner cannot be null");
+        require(_owner != address(0), "WF: empty owner address");
         require(_owner != _guardian, "WF: owner cannot be guardian");
-        require(_modules.length > 0, "WF: cannot assign with less than 1 module");
-        require(_guardian != (address(0)), "WF: guardian cannot be null");        
+        require(_modules.length > 0, "WF: empty modules");
+        require(_guardian != (address(0)), "WF: empty guardian");        
     }
 
     /**

--- a/contracts/infrastructure/base/Managed.sol
+++ b/contracts/infrastructure/base/Managed.sol
@@ -56,6 +56,7 @@ contract Managed is Owned {
     * @param _manager The address of the manager.
     */
     function revokeManager(address _manager) external virtual onlyOwner {
+        // solhint-disable-next-line reason-string
         require(managers[_manager] == true, "M: Target must be an existing manager");
         delete managers[_manager];
         emit ManagerRevoked(_manager);

--- a/contracts/infrastructure/ens/ArgentENSManager.sol
+++ b/contracts/infrastructure/ens/ArgentENSManager.sol
@@ -79,7 +79,7 @@ contract ArgentENSManager is IENSManager, Owned, Managed {
      * @param _ensResolver The address of the ENS resolver contract.
      */
     function changeENSResolver(address _ensResolver) external onlyOwner {
-        require(_ensResolver != address(0), "WF: address cannot be null");
+        require(_ensResolver != address(0), "AEM: cannot set empty resolver");
         ensResolver = IENSResolver(_ensResolver);
         emit ENSResolverChanged(_ensResolver);
     }

--- a/contracts/infrastructure/storage/Storage.sol
+++ b/contracts/infrastructure/storage/Storage.sol
@@ -29,6 +29,7 @@ contract Storage {
      * @notice Throws if the caller is not an authorised module.
      */
     modifier onlyModule(address _wallet) {
+        // solhint-disable-next-line reason-string
         require(IWallet(_wallet).authorised(msg.sender), "TS: must be an authorized module to call this method");
         _;
     }

--- a/contracts/modules/ArgentModule.sol
+++ b/contracts/modules/ArgentModule.sol
@@ -30,7 +30,7 @@ import "./TransactionManager.sol";
  */
 contract ArgentModule is BaseModule, RelayerManager, SecurityManager, TransactionManager {
 
-    bytes32 constant NAME = "ArgentModule";
+    bytes32 constant public NAME = "ArgentModule";
 
     constructor (
         IModuleRegistry _registry,

--- a/contracts/modules/ArgentModule.sol
+++ b/contracts/modules/ArgentModule.sol
@@ -62,7 +62,7 @@ contract ArgentModule is BaseModule, RelayerManager, SecurityManager, Transactio
     * @inheritdoc IModule
     */
     function addModule(address _wallet, address _module) external override onlyWalletOwnerOrSelf(_wallet) onlyWhenUnlocked(_wallet) {
-        require(registry.isRegisteredModule(_module), "BM: module is not registered");
+        require(registry.isRegisteredModule(_module), "AM: module is not registered");
         IWallet(_wallet).authoriseModule(_module, true);
     }
     

--- a/contracts/modules/SimpleUpgrader.sol
+++ b/contracts/modules/SimpleUpgrader.sol
@@ -54,7 +54,7 @@ contract SimpleUpgrader is IModule {
      */
     function init(address _wallet) external override {
         require(msg.sender == _wallet, "SU: only wallet can call init");
-        require(registry.isRegisteredModule(toEnable), "SU: Not all modules are registered");
+        require(registry.isRegisteredModule(toEnable), "SU: module not registered");
 
         uint256 i = 0;
         //add new modules

--- a/contracts/modules/TransactionManager.sol
+++ b/contracts/modules/TransactionManager.sol
@@ -232,8 +232,8 @@ abstract contract TransactionManager is BaseModule {
     }
 
     function startSession(address _wallet, address _sessionUser, uint64 _duration) internal {
-        require(_sessionUser != address(0), "RM: Invalid session user");
-        require(_duration > 0, "RM: Invalid session duration");
+        require(_sessionUser != address(0), "TM: Invalid session user");
+        require(_duration > 0, "TM: Invalid session duration");
 
         uint64 expiry = Utils.safe64(block.timestamp + _duration);
         sessions[_wallet] = Session(_sessionUser, expiry);

--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -83,7 +83,7 @@ abstract contract BaseModule is IModule {
      * @notice Throws if the wallet is not locked.
      */
     modifier onlyWhenLocked(address _wallet) {
-        require(_isLocked(_wallet), "LM: wallet must be locked");
+        require(_isLocked(_wallet), "BM: wallet must be locked");
         _;
     }
 
@@ -91,7 +91,7 @@ abstract contract BaseModule is IModule {
      * @notice Throws if the wallet is locked.
      */
     modifier onlyWhenUnlocked(address _wallet) {
-        require(!_isLocked(_wallet), "BF: wallet locked");
+        require(!_isLocked(_wallet), "BM: wallet locked");
         _;
     }
 

--- a/contracts/modules/common/Utils.sol
+++ b/contracts/modules/common/Utils.sol
@@ -52,7 +52,7 @@ library Utils {
     * @notice Helper method to parse data and extract the method signature.
     */
     function functionPrefix(bytes memory _data) internal pure returns (bytes4 prefix) {
-        require(_data.length >= 4, "RM: Invalid functionPrefix");
+        require(_data.length >= 4, "Utils: Invalid functionPrefix");
         // solhint-disable-next-line no-inline-assembly
         assembly {
             prefix := mload(add(_data, 0x20))
@@ -79,12 +79,12 @@ library Utils {
     }
 
     function safe128(uint256 _num) internal pure returns (uint128) {
-        require(_num < 2**128, "LU: more then 128 bits");
+        require(_num < 2**128, "Utils: more then 128 bits");
         return uint128(_num);
     }
 
     function safe64(uint256 _num) internal pure returns (uint64) {
-        require(_num < 2**64, "LU: more then 64 bits");
+        require(_num < 2**64, "Utils: more then 64 bits");
         return uint64(_num);
     }
 }

--- a/contracts/modules/common/Utils.sol
+++ b/contracts/modules/common/Utils.sol
@@ -41,7 +41,7 @@ library Utils {
             s := mload(add(_signatures, add(0x40,mul(0x41,_index))))
             v := and(mload(add(_signatures, add(0x41,mul(0x41,_index)))), 0xff)
         }
-        require(v == 27 || v == 28);
+        require(v == 27 || v == 28, "Utils: bad v value in signature");
 
         address recoveredAddress = ecrecover(_signedHash, v, r, s);
         require(recoveredAddress != address(0), "Utils: ecrecover returned 0");

--- a/contracts/wallet/BaseWallet.sol
+++ b/contracts/wallet/BaseWallet.sol
@@ -46,7 +46,7 @@ contract BaseWallet is IWallet {
      * @notice Throws if the sender is not an authorised module.
      */
     modifier moduleOnly {
-        require(authorised[msg.sender], "BW: msg.sender not an authorized module");
+        require(authorised[msg.sender], "BW: sender not authorized");
         _;
     }
 
@@ -57,7 +57,7 @@ contract BaseWallet is IWallet {
      */
     function init(address _owner, address[] calldata _modules) external {
         require(owner == address(0) && modules == 0, "BW: wallet already initialised");
-        require(_modules.length > 0, "BW: construction requires at least 1 module");
+        require(_modules.length > 0, "BW: empty modules");
         owner = _owner;
         modules = _modules.length;
         for (uint256 i = 0; i < _modules.length; i++) {
@@ -83,7 +83,7 @@ contract BaseWallet is IWallet {
                 IModule(_module).init(address(this));
             } else {
                 modules -= 1;
-                require(modules > 0, "BW: wallet must have at least one module");
+                require(modules > 0, "BW: cannot remove last module");
                 delete authorised[_module];
             }
         }
@@ -105,7 +105,7 @@ contract BaseWallet is IWallet {
     */
     function enableStaticCall(address _module, bytes4 /* _method */) external override moduleOnly {
         if(staticCallExecutor != _module) {
-            require(authorised[_module], "BW: static call executor must be authorised module");
+            require(authorised[_module], "BW: unauthorized executor");
             staticCallExecutor = _module;
         }
     }
@@ -147,7 +147,7 @@ contract BaseWallet is IWallet {
         if (module == address(0)) {
             emit Received(msg.value, msg.sender, msg.data);
         } else {
-            require(authorised[module], "BW: must be an authorised module for static call");
+            require(authorised[module], "BW: unauthorised module");
 
             // solhint-disable-next-line no-inline-assembly
             assembly {

--- a/test/authorisation.js
+++ b/test/authorisation.js
@@ -349,7 +349,7 @@ contract("Authorisation", (accounts) => {
         [owner]);
       const { success, error } = await utils.parseRelayReceipt(txReceipt);
       assert.isFalse(success, "toggleRegistry should have failed");
-      assert.equal(error, "AR: unknown registry");
+      assert.equal(error, "DR: unknown registry");
     });
   });
 
@@ -358,12 +358,12 @@ contract("Authorisation", (accounts) => {
   describe("add registry", () => {
     it("should not create a duplicate registry", async () => {
       await truffleAssert.reverts(
-        dappRegistry.createRegistry(CUSTOM_REGISTRY_ID, registryOwner, { from: infrastructure }), "AR: duplicate registry"
+        dappRegistry.createRegistry(CUSTOM_REGISTRY_ID, registryOwner, { from: infrastructure }), "DR: duplicate registry"
       );
     });
     it("should not create a registry without owner", async () => {
       await truffleAssert.reverts(
-        dappRegistry.createRegistry(CUSTOM_REGISTRY_ID, ZERO_ADDRESS, { from: infrastructure }), "AR: registry owner is 0"
+        dappRegistry.createRegistry(CUSTOM_REGISTRY_ID, ZERO_ADDRESS, { from: infrastructure }), "DR: registry owner is 0"
       );
     });
   });
@@ -380,7 +380,7 @@ contract("Authorisation", (accounts) => {
 
     it("can't change a registry to null owner", async () => {
       await truffleAssert.reverts(
-        dappRegistry.changeOwner(0, ZERO_ADDRESS, { from: infrastructure }), "AR: new registry owner is 0"
+        dappRegistry.changeOwner(0, ZERO_ADDRESS, { from: infrastructure }), "DR: new registry owner is 0"
       );
     });
   });
@@ -391,7 +391,7 @@ contract("Authorisation", (accounts) => {
       const requestedTl = 12;
       await dappRegistry.requestTimelockChange(requestedTl, { from: infrastructure });
       await truffleAssert.reverts(
-        dappRegistry.confirmTimelockChange(), "AR: can't (yet) change timelock"
+        dappRegistry.confirmTimelockChange(), "DR: can't (yet) change timelock"
       );
       let newTl = (await dappRegistry.timelockPeriod()).toNumber();
       assert.equal(newTl, tl, "timelock shouldn't have changed");
@@ -418,22 +418,22 @@ contract("Authorisation", (accounts) => {
     it("should not allow registry owner to add duplicate dapp", async () => {
       await dappRegistry.addDapp(0, contract2.address, filter.address, { from: infrastructure });
       await truffleAssert.reverts(
-        dappRegistry.addDapp(0, contract2.address, filter.address, { from: infrastructure }), "AR: dapp already added"
+        dappRegistry.addDapp(0, contract2.address, filter.address, { from: infrastructure }), "DR: dapp already added"
       );
     });
     it("should not allow non-owner to add authorisation to the Argent registry", async () => {
       await truffleAssert.reverts(
-        dappRegistry.addDapp(0, contract2.address, filter.address, { from: nonwhitelisted }), "AR: sender != registry owner"
+        dappRegistry.addDapp(0, contract2.address, filter.address, { from: nonwhitelisted }), "DR: sender != registry owner"
       );
     });
     it("should not allow adding authorisation to unknown registry", async () => {
       await truffleAssert.reverts(
-        dappRegistry.addDapp(66, contract2.address, filter.address, { from: nonwhitelisted }), "AR: unknown registry"
+        dappRegistry.addDapp(66, contract2.address, filter.address, { from: nonwhitelisted }), "DR: unknown registry"
       );
     });
     it("should allow registry owner to remove a dapp", async () => {
       await truffleAssert.reverts(
-        dappRegistry.removeDapp(0, contract2.address, { from: infrastructure }), "AR: unknown dapp"
+        dappRegistry.removeDapp(0, contract2.address, { from: infrastructure }), "DR: unknown dapp"
       );
       await dappRegistry.addDapp(0, contract2.address, ZERO_ADDRESS, { from: infrastructure });
       await dappRegistry.removeDapp(0, contract2.address, { from: infrastructure });
@@ -450,7 +450,7 @@ contract("Authorisation", (accounts) => {
       await dappRegistry.requestFilterUpdate(0, contract2.address, filter2.address, { from: infrastructure });
       await truffleAssert.reverts(
         dappRegistry.confirmFilterUpdate(0, contract2.address, { from: infrastructure }),
-        "AR: too early to confirm auth"
+        "DR: too early to confirm auth"
       );
       const tl = (await dappRegistry.timelockPeriod()).toNumber();
       await utils.increaseTime(tl + 1);
@@ -461,13 +461,13 @@ contract("Authorisation", (accounts) => {
     it("should not allow changing filter for a non-existing dapp", async () => {
       await truffleAssert.reverts(
         dappRegistry.requestFilterUpdate(0, contract2.address, filter.address, { from: infrastructure }),
-        "AR: unknown dapp"
+        "DR: unknown dapp"
       );
     });
     it("should not allow confirming change of a non-existing pending change", async () => {
       await truffleAssert.reverts(
         dappRegistry.confirmFilterUpdate(0, contract2.address, { from: infrastructure }),
-        "AR: no pending filter update"
+        "DR: no pending filter update"
       );
     });
   });

--- a/test/ens.js
+++ b/test/ens.js
@@ -198,7 +198,7 @@ contract("ENS contracts", (accounts) => {
     });
 
     it("should not be able to change the ens resolver to an empty address", async () => {
-      await truffleAssert.reverts(ensManager.changeENSResolver(ethers.constants.AddressZero), "WF: address cannot be null");
+      await truffleAssert.reverts(ensManager.changeENSResolver(ethers.constants.AddressZero), "AEM: cannot set empty resolver");
     });
   });
 

--- a/test/factory.js
+++ b/test/factory.js
@@ -96,21 +96,21 @@ contract("WalletFactory", (accounts) => {
       await truffleAssert.reverts(Factory.new(
         ZERO_ADDRESS,
         guardianStorage.address,
-        refundAddress), "WF: WalletImplementation address not defined");
+        refundAddress), "WF: empty wallet implementation");
     });
 
     it("should not allow to be created with empty GuardianStorage", async () => {
       await truffleAssert.reverts(Factory.new(
         implementation.address,
         ZERO_ADDRESS,
-        refundAddress), "WF: GuardianStorage address not defined");
+        refundAddress), "WF: empty guardian storage");
     });
 
     it("should not allow to be created with empty refund address", async () => {
       await truffleAssert.reverts(Factory.new(
         implementation.address,
         guardianStorage.address,
-        ZERO_ADDRESS), "WF: refund address not defined");
+        ZERO_ADDRESS), "WF: empty refund address");
     });
 
     it("should allow owner to change the refund address", async () => {
@@ -121,7 +121,7 @@ contract("WalletFactory", (accounts) => {
     });
 
     it("should not allow owner to change the refund address to zero address", async () => {
-      await truffleAssert.reverts(factory.changeRefundAddress(ZERO_ADDRESS), "WF: address cannot be null");
+      await truffleAssert.reverts(factory.changeRefundAddress(ZERO_ADDRESS), "WF: cannot set to empty");
     });
 
     it("should not allow non-owner to change the refund address", async () => {
@@ -343,7 +343,7 @@ contract("WalletFactory", (accounts) => {
       const salt = generateSaltValue();
       await truffleAssert.reverts(
         factory.createCounterfactualWallet(ZERO_ADDRESS, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x"),
-        "WF: owner cannot be null",
+        "WF: empty owner address",
       );
     });
 
@@ -351,7 +351,7 @@ contract("WalletFactory", (accounts) => {
       const salt = generateSaltValue();
       await truffleAssert.reverts(
         factory.createCounterfactualWallet(owner, modules, ZERO_ADDRESS, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x"),
-        "WF: guardian cannot be null",
+        "WF: empty guardian",
       );
     });
 
@@ -392,7 +392,7 @@ contract("WalletFactory", (accounts) => {
       const salt = generateSaltValue();
       await truffleAssert.reverts(
         factory.getAddressForCounterfactualWallet(owner, modules, ZERO_ADDRESS, salt),
-        "WF: guardian cannot be null",
+        "WF: empty guardian",
       );
     });
   });

--- a/test/session.js
+++ b/test/session.js
@@ -207,7 +207,7 @@ contract("ArgentModule sessions", (accounts) => {
 
       const { success, error } = utils.parseRelayReceipt(txReceipt);
       assert.isFalse(success);
-      assert.equal(error, "RM: Invalid session user");
+      assert.equal(error, "TM: Invalid session user");
     });
 
     it("should not be able to start a session for zero duration", async () => {
@@ -223,7 +223,7 @@ contract("ArgentModule sessions", (accounts) => {
 
       const { success, error } = utils.parseRelayReceipt(txReceipt);
       assert.isFalse(success);
-      assert.equal(error, "RM: Invalid session duration");
+      assert.equal(error, "TM: Invalid session duration");
     });
 
     it("owner should be able to clear a session", async () => {


### PR DESCRIPTION
Improving the revert error messages to:
- shorten them under 32 characters long. Also enable that rule in solhint linter as error so we can't overstep in future.
- make consistent the prefixes with contract name abbreviation


