### PR TITLE
Safer recoverSpender

### DIFF
--- a/contracts/modules/TransactionManager.sol
+++ b/contracts/modules/TransactionManager.sol
@@ -30,7 +30,7 @@ import "../../lib/other/ERC20.sol";
 abstract contract TransactionManager is BaseModule {
     // ERC20 & ERC721 transfers & approvals
     bytes4 private constant ERC20_TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
-    bytes4 private constant ERC20_APPROVE = bytes4(keccak256("transferFrom(address,address,uint256)"));
+    bytes4 private constant ERC20_APPROVE = bytes4(keccak256("approve(address,uint256)"));
     bytes4 private constant ERC721_TRANSFER_FROM = bytes4(keccak256("transferFrom(address,address,uint256)"));
     bytes4 private constant ERC721_SAFE_TRANSFER_FROM = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
     bytes4 private constant ERC721_SAFE_TRANSFER_FROM_BYTES = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));

--- a/contracts/modules/TransactionManager.sol
+++ b/contracts/modules/TransactionManager.sol
@@ -282,7 +282,12 @@ abstract contract TransactionManager is BaseModule {
     }
 
     function recoverSpender(address _wallet, Call calldata _transaction) internal pure returns (address) {
-        bytes4 methodId = Utils.functionPrefix(_transaction.data);
+        bytes4 methodId;
+        bytes memory data = _transaction.data;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            methodId := mload(add(data, 0x20))
+        }
         if(
             methodId == ERC20_TRANSFER ||
             methodId == ERC20_APPROVE ||

--- a/contracts/modules/TransactionManager.sol
+++ b/contracts/modules/TransactionManager.sol
@@ -282,24 +282,26 @@ abstract contract TransactionManager is BaseModule {
     }
 
     function recoverSpender(address _wallet, Call calldata _transaction) internal pure returns (address) {
-        bytes4 methodId;
-        bytes memory data = _transaction.data;
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            methodId := mload(add(data, 0x20))
-        }
-        if(
-            methodId == ERC20_TRANSFER ||
-            methodId == ERC20_APPROVE ||
-            methodId == ERC721_TRANSFER_FROM ||
-            methodId == ERC721_SAFE_TRANSFER_FROM ||
-            methodId == ERC721_SAFE_TRANSFER_FROM_BYTES ||
-            methodId == ERC721_SET_APPROVAL_FOR_ALL ||
-            methodId == ERC1155_SAFE_TRANSFER_FROM
-        ) {
-            require(_transaction.value == 0, "TM: unsecure call");
-            (address first, address second) = abi.decode(_transaction.data[4:], (address, address));
-            return first == _wallet ? second : first;
+        if(_transaction.data.length >= 4) {
+            bytes4 methodId;
+            bytes memory data = _transaction.data;
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                methodId := mload(add(data, 0x20))
+            }
+            if(
+                methodId == ERC20_TRANSFER ||
+                methodId == ERC20_APPROVE ||
+                methodId == ERC721_TRANSFER_FROM ||
+                methodId == ERC721_SAFE_TRANSFER_FROM ||
+                methodId == ERC721_SAFE_TRANSFER_FROM_BYTES ||
+                methodId == ERC721_SET_APPROVAL_FOR_ALL ||
+                methodId == ERC1155_SAFE_TRANSFER_FROM
+            ) {
+                require(_transaction.value == 0, "TM: unsecure call");
+                (address first, address second) = abi.decode(_transaction.data[4:], (address, address));
+                return first == _wallet ? second : first;
+            }
         }
         return _transaction.to;
     }

--- a/contracts/modules/TransactionManager.sol
+++ b/contracts/modules/TransactionManager.sol
@@ -28,13 +28,14 @@ import "../../lib/other/ERC20.sol";
  * @author Julien Niset - <julien@argent.xyz>
  */
 abstract contract TransactionManager is BaseModule {
-    // ERC20 & ERC721 transfers & approvals
+    // ERC20, ERC721 & ERC1155 transfers & approvals
     bytes4 private constant ERC20_TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     bytes4 private constant ERC20_APPROVE = bytes4(keccak256("approve(address,uint256)"));
     bytes4 private constant ERC721_TRANSFER_FROM = bytes4(keccak256("transferFrom(address,address,uint256)"));
     bytes4 private constant ERC721_SAFE_TRANSFER_FROM = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
     bytes4 private constant ERC721_SAFE_TRANSFER_FROM_BYTES = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
     bytes4 private constant ERC721_SET_APPROVAL_FOR_ALL = bytes4(keccak256("setApprovalForAll(address,bool)"));
+    bytes4 private constant ERC1155_SAFE_TRANSFER_FROM = bytes4(keccak256("safeTransferFrom(address,address,uint256,uint256,bytes)"));
 
     // Static calls
     bytes4 private constant ERC1271_IS_VALID_SIGNATURE = bytes4(keccak256("isValidSignature(bytes32,bytes)"));
@@ -288,7 +289,8 @@ abstract contract TransactionManager is BaseModule {
             methodId == ERC721_TRANSFER_FROM ||
             methodId == ERC721_SAFE_TRANSFER_FROM ||
             methodId == ERC721_SAFE_TRANSFER_FROM_BYTES ||
-            methodId == ERC721_SET_APPROVAL_FOR_ALL
+            methodId == ERC721_SET_APPROVAL_FOR_ALL ||
+            methodId == ERC1155_SAFE_TRANSFER_FROM
         ) {
             require(_transaction.value == 0, "TM: unsecure call");
             (address first, address second) = abi.decode(_transaction.data[4:], (address, address));

--- a/contracts/modules/TransactionManager.sol
+++ b/contracts/modules/TransactionManager.sol
@@ -32,6 +32,9 @@ abstract contract TransactionManager is BaseModule {
     bytes4 private constant ERC20_TRANSFER = bytes4(keccak256("transfer(address,uint256)"));
     bytes4 private constant ERC20_APPROVE = bytes4(keccak256("approve(address,uint256)"));
     bytes4 private constant ERC721_TRANSFER_FROM = bytes4(keccak256("transferFrom(address,address,uint256)"));
+    bytes4 private constant ERC721_SAFE_TRANSFER_FROM = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
+    bytes4 private constant ERC721_SAFE_TRANSFER_FROM_BYTES = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
+    bytes4 private constant ERC721_SET_APPROVAL_FOR_ALL = bytes4(keccak256("setApprovalForAll(address,bool)"));
 
     // Static calls
     bytes4 private constant ERC1271_IS_VALID_SIGNATURE = bytes4(keccak256("isValidSignature(bytes32,bytes)"));
@@ -279,7 +282,14 @@ abstract contract TransactionManager is BaseModule {
 
     function recoverSpender(address _wallet, Call calldata _transaction) internal pure returns (address) {
         bytes4 methodId = Utils.functionPrefix(_transaction.data);
-        if(methodId == ERC20_TRANSFER || methodId == ERC20_APPROVE || methodId == ERC721_TRANSFER_FROM) {
+        if(
+            methodId == ERC20_TRANSFER ||
+            methodId == ERC20_APPROVE ||
+            methodId == ERC721_TRANSFER_FROM ||
+            methodId == ERC721_SAFE_TRANSFER_FROM ||
+            methodId == ERC721_SAFE_TRANSFER_FROM_BYTES ||
+            methodId == ERC721_SET_APPROVAL_FOR_ALL
+        ) {
             require(_transaction.value == 0, "TM: unsecure call");
             (address first, address second) = abi.decode(_transaction.data[4:], (address, address));
             return first == _wallet ? second : first;

--- a/test/asset.js
+++ b/test/asset.js
@@ -111,7 +111,7 @@ contract("ArgentModule", (accounts) => {
       await addTrustedContact(wallet, recipient, module, SECURITY_PERIOD);
     });
 
-    it.only("should send and receive ETH", async () => {
+    it("should send and receive ETH", async () => {
       // receive
       let before = await utils.getBalance(wallet.address);
       await wallet.send(web3.utils.toWei("1"), { from: sender });

--- a/test/authorisation.js
+++ b/test/authorisation.js
@@ -108,7 +108,7 @@ contract("Authorisation", (accounts) => {
   async function enableCustomRegistry() {
     assert.equal(await dappRegistry.isEnabledRegistry(wallet.address, CUSTOM_REGISTRY_ID), false, "custom registry should not be enabled");
     const data = dappRegistry.contract.methods.toggleRegistry(CUSTOM_REGISTRY_ID, true).encodeABI();
-    const transaction = encodeTransaction(dappRegistry.address, 0, data, false);
+    const transaction = encodeTransaction(dappRegistry.address, 0, data);
     const txReceipt = await manager.relay(
       module,
       "multiCall",
@@ -160,7 +160,7 @@ contract("Authorisation", (accounts) => {
 
     it("should call authorised contract when filter passes (argent registry)", async () => {
       const data = contract.contract.methods.setState(4).encodeABI();
-      const transaction = encodeTransaction(contract.address, 0, data, false);
+      const transaction = encodeTransaction(contract.address, 0, data);
 
       const txReceipt = await manager.relay(
         module,
@@ -179,7 +179,7 @@ contract("Authorisation", (accounts) => {
 
     it("should call authorised contract when filter passes (community registry)", async () => {
       const data = contract2.contract.methods.setState(4).encodeABI();
-      const transaction = encodeTransaction(contract2.address, 0, data, false);
+      const transaction = encodeTransaction(contract2.address, 0, data);
 
       const txReceipt = await manager.relay(
         module,
@@ -198,7 +198,7 @@ contract("Authorisation", (accounts) => {
 
     it("should block call to authorised contract when filter doesn't pass", async () => {
       const data = contract.contract.methods.setState(5).encodeABI();
-      const transaction = encodeTransaction(contract.address, 0, data, false);
+      const transaction = encodeTransaction(contract.address, 0, data);
 
       const txReceipt = await manager.relay(
         module,
@@ -215,7 +215,7 @@ contract("Authorisation", (accounts) => {
     });
 
     it("should not send ETH to unauthorised address", async () => {
-      const transaction = encodeTransaction(nonwhitelisted, 100, ZERO_BYTES32, false);
+      const transaction = encodeTransaction(nonwhitelisted, 100, ZERO_BYTES32);
 
       const txReceipt = await manager.relay(
         module,
@@ -242,11 +242,11 @@ contract("Authorisation", (accounts) => {
       const transactions = [];
 
       let data = erc20.contract.methods.approve(contract.address, 100).encodeABI();
-      let transaction = encodeTransaction(erc20.address, 0, data, true);
+      let transaction = encodeTransaction(erc20.address, 0, data);
       transactions.push(transaction);
 
       data = contract.contract.methods.setStateAndPayToken(4, erc20.address, 100).encodeABI();
-      transaction = encodeTransaction(contract.address, 0, data, false);
+      transaction = encodeTransaction(contract.address, 0, data);
       transactions.push(transaction);
 
       const txReceipt = await manager.relay(
@@ -268,11 +268,11 @@ contract("Authorisation", (accounts) => {
       const transactions = [];
 
       let data = erc20.contract.methods.approve(contract.address, 100).encodeABI();
-      let transaction = encodeTransaction(erc20.address, 0, data, true);
+      let transaction = encodeTransaction(erc20.address, 0, data);
       transactions.push(transaction);
 
       data = contract.contract.methods.setStateAndPayToken(5, erc20.address, 100).encodeABI();
-      transaction = encodeTransaction(contract.address, 0, data, false);
+      transaction = encodeTransaction(contract.address, 0, data);
       transactions.push(transaction);
 
       const txReceipt = await manager.relay(
@@ -313,7 +313,7 @@ contract("Authorisation", (accounts) => {
 
     it("should not enable non-existing registry", async () => {
       const data = dappRegistry.contract.methods.toggleRegistry(66, true).encodeABI();
-      const transaction = encodeTransaction(dappRegistry.address, 0, data, false);
+      const transaction = encodeTransaction(dappRegistry.address, 0, data);
       const txReceipt = await manager.relay(
         module,
         "multiCall",

--- a/test/authorisation.js
+++ b/test/authorisation.js
@@ -25,7 +25,7 @@ const truffleAssert = require("truffle-assertions");
 const utils = require("../utils/utilities.js");
 const { ETH_TOKEN, encodeTransaction, initNonce } = require("../utils/utilities.js");
 
-const ZERO_BYTES32 = ethers.constants.HashZero;
+const ZERO_BYTES = "0x";
 const ZERO_ADDRESS = ethers.constants.AddressZero;
 const SECURITY_PERIOD = 2;
 const SECURITY_WINDOW = 2;
@@ -143,7 +143,7 @@ contract("Authorisation", (accounts) => {
     });
 
     it("should send ETH to authorised address", async () => {
-      const transaction = encodeTransaction(recipient, 100, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 100, ZERO_BYTES);
       const txReceipt = await manager.relay(
         module,
         "multiCall",
@@ -215,7 +215,7 @@ contract("Authorisation", (accounts) => {
     });
 
     it("should not send ETH to unauthorised address", async () => {
-      const transaction = encodeTransaction(nonwhitelisted, 100, ZERO_BYTES32);
+      const transaction = encodeTransaction(nonwhitelisted, 100, ZERO_BYTES);
 
       const txReceipt = await manager.relay(
         module,

--- a/test/compound.js
+++ b/test/compound.js
@@ -212,7 +212,7 @@ contract("ArgentModule", (accounts) => {
         investInEth = false;
 
         let data = token.contract.methods.approve(cToken.address, amount).encodeABI();
-        let transaction = encodeTransaction(token.address, 0, data, true);
+        let transaction = encodeTransaction(token.address, 0, data);
         transactions.push(transaction);
 
         data = cToken.contract.methods.mint(amount).encodeABI();

--- a/test/ens.js
+++ b/test/ens.js
@@ -315,7 +315,7 @@ contract("ENS contracts", (accounts) => {
       const transactions = [];
       // build the claimWithResolver call
       let data = ensReverse.contract.methods.claimWithResolver(ensManager.address, ensResolver.address).encodeABI();
-      let transaction = encodeTransaction(ensReverse.address, 0, data, false);
+      let transaction = encodeTransaction(ensReverse.address, 0, data);
       transactions.push(transaction);
 
       // build the ens register call

--- a/test/factory.js
+++ b/test/factory.js
@@ -15,7 +15,7 @@ const utils = require("../utils/utilities.js");
 const { ETH_TOKEN } = require("../utils/utilities.js");
 
 const ZERO_ADDRESS = ethers.constants.AddressZero;
-const ZERO_BYTES32 = ethers.constants.HashZero;
+const ZERO_BYTES = "0x";
 
 const SECURITY_PERIOD = 2;
 const SECURITY_WINDOW = 2;
@@ -140,7 +140,7 @@ contract("WalletFactory", (accounts) => {
 
       // we create the wallet
       const tx = await factory.createCounterfactualWallet(
-        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, managerSig, { from: infrastructure });
+        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES, managerSig, { from: infrastructure });
 
       const event = await utils.getEvent(tx.receipt, factory, "WalletCreated");
       const walletAddr = event.args.wallet;
@@ -170,7 +170,7 @@ contract("WalletFactory", (accounts) => {
 
       // we create the wallet
       const tx = await factory.createCounterfactualWallet(
-        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, managerSig, { from: owner });
+        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES, managerSig, { from: owner });
 
       const event = await utils.getEvent(tx.receipt, factory, "WalletCreated");
       const walletAddr = event.args.wallet;
@@ -186,7 +186,7 @@ contract("WalletFactory", (accounts) => {
       const msg = ethers.utils.hexZeroPad(futureAddr, 32);
       const managerSig = await utils.signMessage(msg, infrastructure);
       const tx = await factory.createCounterfactualWallet(
-        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, managerSig, { from: owner });
+        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES, managerSig, { from: owner });
       const event = await utils.getEvent(tx.receipt, factory, "WalletCreated");
       const walletAddr = event.args.wallet;
       const wallet = await BaseWallet.at(walletAddr);
@@ -305,14 +305,14 @@ contract("WalletFactory", (accounts) => {
       const futureAddr = await factory.getAddressForCounterfactualWallet(owner, modules, guardian, salt);
       // we create the first wallet
       const tx = await factory.createCounterfactualWallet(
-        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x"
+        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES, "0x"
       );
       const event = await utils.getEvent(tx.receipt, factory, "WalletCreated");
       // we test that the wallet is at the correct address
       assert.equal(futureAddr, event.args.wallet, "should have the correct address");
       // we create the second wallet
       await truffleAssert.reverts(
-        factory.createCounterfactualWallet(owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x")
+        factory.createCounterfactualWallet(owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES, "0x")
       );
     });
 
@@ -335,14 +335,14 @@ contract("WalletFactory", (accounts) => {
       const salt = generateSaltValue();
       await truffleAssert.reverts(
         factory.createCounterfactualWallet(
-          owner, [ethers.constants.AddressZero], guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x"
+          owner, [ethers.constants.AddressZero], guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES, "0x"
         ));
     });
 
     it("should fail to create when the owner is empty", async () => {
       const salt = generateSaltValue();
       await truffleAssert.reverts(
-        factory.createCounterfactualWallet(ZERO_ADDRESS, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x"),
+        factory.createCounterfactualWallet(ZERO_ADDRESS, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES, "0x"),
         "WF: empty owner address",
       );
     });
@@ -350,7 +350,7 @@ contract("WalletFactory", (accounts) => {
     it("should fail to create when the guardian is empty", async () => {
       const salt = generateSaltValue();
       await truffleAssert.reverts(
-        factory.createCounterfactualWallet(owner, modules, ZERO_ADDRESS, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x"),
+        factory.createCounterfactualWallet(owner, modules, ZERO_ADDRESS, salt, 0, ZERO_ADDRESS, ZERO_BYTES, "0x"),
         "WF: empty guardian",
       );
     });
@@ -358,7 +358,7 @@ contract("WalletFactory", (accounts) => {
     it("should fail to create when the owner is the guardian", async () => {
       const salt = generateSaltValue();
       await truffleAssert.reverts(
-        factory.createCounterfactualWallet(owner, modules, owner, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x"),
+        factory.createCounterfactualWallet(owner, modules, owner, salt, 0, ZERO_ADDRESS, ZERO_BYTES, "0x"),
         "WF: owner cannot be guardian",
       );
     });
@@ -366,7 +366,7 @@ contract("WalletFactory", (accounts) => {
     it("should fail to create by a non-manager without a manager's signature", async () => {
       const salt = generateSaltValue();
       await truffleAssert.reverts(
-        factory.createCounterfactualWallet(owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x", { from: other }),
+        factory.createCounterfactualWallet(owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES, "0x", { from: other }),
         "WF: unauthorised wallet creation",
       );
     });
@@ -380,7 +380,7 @@ contract("WalletFactory", (accounts) => {
       await web3.eth.sendTransaction({ from: infrastructure, to: futureAddr, value: amount });
       // we create the wallet
       const tx = await factory.createCounterfactualWallet(
-        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES32, "0x"
+        owner, modules, guardian, salt, 0, ZERO_ADDRESS, ZERO_BYTES, "0x"
       );
       const wallet = await BaseWallet.at(futureAddr);
       const event = await utils.getEvent(tx.receipt, wallet, "Received");

--- a/test/paraswap.js
+++ b/test/paraswap.js
@@ -279,7 +279,7 @@ contract("ArgentModule", (accounts) => {
       } else {
         data = tokenB.contract.methods.approve(paraswapProxy, srcAmount).encodeABI();
       }
-      transaction = encodeTransaction(fromToken, 0, data, true);
+      transaction = encodeTransaction(fromToken, 0, data);
       transactions.push(transaction);
     }
 

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -232,7 +232,7 @@ contract("ArgentModule", (accounts) => {
       const balanceStart = await utils.getBalance(wallet.address);
       // send erc20
       const data = token.contract.methods.transfer(recipient, 100).encodeABI();
-      const transaction = encodeTransaction(token.address, 0, data, true);
+      const transaction = encodeTransaction(token.address, 0, data);
 
       const txReceipt = await manager.relay(
         module,
@@ -253,7 +253,7 @@ contract("ArgentModule", (accounts) => {
       // token balance
       const balanceStart = await token.balanceOf(relayer);
       // send ETH
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32, false);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
       const txReceipt = await manager.relay(
         module,
         "multiCall",
@@ -303,7 +303,7 @@ contract("ArgentModule", (accounts) => {
     it("should fail when there is not enough ERC20 to refund", async () => {
       const balance = await token.balanceOf(wallet.address);
       const data = token.contract.methods.transfer(recipient, balance.toString()).encodeABI();
-      const transaction = encodeTransaction(token.address, 0, data, true);
+      const transaction = encodeTransaction(token.address, 0, data);
 
       await truffleAssert.reverts(
         manager.relay(

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -26,7 +26,7 @@ const ERC20 = artifacts.require("TestERC20");
 const utils = require("../utils/utilities.js");
 const { ETH_TOKEN, encodeTransaction, addTrustedContact, initNonce } = require("../utils/utilities.js");
 
-const ZERO_BYTES32 = ethers.constants.HashZero;
+const ZERO_BYTES = "0x";
 const ZERO_ADDRESS = ethers.constants.AddressZero;
 const SECURITY_PERIOD = 2;
 const SECURITY_WINDOW = 2;
@@ -128,7 +128,7 @@ contract("ArgentModule", (accounts) => {
     });
 
     it("should fail when the first param is not the wallet", async () => {
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
       await truffleAssert.reverts(
         manager.relay(module, "multiCall", [infrastructure, [transaction]], wallet, [owner]),
         "RM: Target of _data != _wallet"
@@ -154,7 +154,7 @@ contract("ArgentModule", (accounts) => {
     });
 
     it("should fail when a wrong number of signatures is provided", async () => {
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
       await truffleAssert.reverts(
         manager.relay(module, "multiCall", [wallet.address, [transaction]], wallet, [owner, recipient]),
         "RM: Wrong number of signatures"
@@ -165,7 +165,7 @@ contract("ArgentModule", (accounts) => {
       const nonce = await utils.getNonceForRelay();
       const chainId = await utils.getChainId();
       const gasLimit = 100000;
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
       const methodData = module.contract.methods.multiCall(wallet.address, [transaction]).encodeABI();
       const signatures = await utils.signOffchain(
         [owner],
@@ -204,7 +204,7 @@ contract("ArgentModule", (accounts) => {
     });
 
     it("should update the nonce after the transaction", async () => {
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
 
       const nonceBefore = await module.getNonce(wallet.address);
       await manager.relay(
@@ -253,7 +253,7 @@ contract("ArgentModule", (accounts) => {
       // token balance
       const balanceStart = await token.balanceOf(relayer);
       // send ETH
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
       const txReceipt = await manager.relay(
         module,
         "multiCall",
@@ -270,7 +270,7 @@ contract("ArgentModule", (accounts) => {
     });
 
     it("should emit the Refund event", async () => {
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
       const txReceipt = await manager.relay(
         module,
         "multiCall",
@@ -285,7 +285,7 @@ contract("ArgentModule", (accounts) => {
 
     it("should fail when there is not enough ETH to refund", async () => {
       const balance = await utils.getBalance(wallet.address);
-      const transaction = encodeTransaction(recipient, balance.toString(), ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, balance.toString(), ZERO_BYTES);
 
       await truffleAssert.reverts(
         manager.relay(

--- a/test/session.js
+++ b/test/session.js
@@ -23,7 +23,7 @@ const UniswapV2Router01 = artifacts.require("DummyUniV2Router");
 const utils = require("../utils/utilities.js");
 const { ETH_TOKEN, encodeTransaction, initNonce } = require("../utils/utilities.js");
 
-const ZERO_BYTES32 = ethers.constants.HashZero;
+const ZERO_BYTES = "0x";
 const ZERO_ADDRESS = ethers.constants.AddressZero;
 const SECURITY_PERIOD = 2;
 const SECURITY_WINDOW = 2;
@@ -256,7 +256,7 @@ contract("ArgentModule sessions", (accounts) => {
 
   describe("approved transfer (without using a session)", () => {
     it("should be able to send ETH with guardians", async () => {
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
 
       const balanceBefore = await utils.getBalance(recipient);
       const txReceipt = await manager.relay(
@@ -314,7 +314,7 @@ contract("ArgentModule sessions", (accounts) => {
     });
 
     it("should be able to send ETH", async () => {
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
 
       const balanceBefore = await utils.getBalance(recipient);
       const txReceipt = await manager.relay(
@@ -356,7 +356,7 @@ contract("ArgentModule sessions", (accounts) => {
     });
 
     it("should not be able to send ETH with invalid session", async () => {
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
 
       await truffleAssert.reverts(manager.relay(
         module,

--- a/test/whitelist.js
+++ b/test/whitelist.js
@@ -142,7 +142,7 @@ contract("ArgentModule", (accounts) => {
       await addTrustedContact(wallet, recipient, module, SECURITY_PERIOD);
       const balanceStart = await utils.getBalance(recipient);
 
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32, false);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
 
       const txReceipt = await manager.relay(
         module,
@@ -174,7 +174,7 @@ contract("ArgentModule", (accounts) => {
       const balanceStart = await erc20.balanceOf(recipient);
 
       const data = erc20.contract.methods.transfer(recipient, 100).encodeABI();
-      const transaction = encodeTransaction(erc20.address, 0, data, true);
+      const transaction = encodeTransaction(erc20.address, 0, data);
 
       const txReceipt = await manager.relay(
         module,
@@ -196,7 +196,7 @@ contract("ArgentModule", (accounts) => {
       await addTrustedContact(wallet, recipient, module, SECURITY_PERIOD);
 
       const data = erc20.contract.methods.approve(recipient, 100).encodeABI();
-      const transaction = encodeTransaction(erc20.address, 0, data, true);
+      const transaction = encodeTransaction(erc20.address, 0, data);
 
       const txReceipt = await manager.relay(
         module,
@@ -230,7 +230,7 @@ contract("ArgentModule", (accounts) => {
       await addTrustedContact(wallet, recipient, module, SECURITY_PERIOD);
 
       const data = erc721.contract.methods.safeTransferFrom(wallet.address, recipient, tokenId).encodeABI();
-      const transaction = encodeTransaction(erc721.address, 0, data, true);
+      const transaction = encodeTransaction(erc721.address, 0, data);
 
       const txReceipt = await manager.relay(
         module,

--- a/test/whitelist.js
+++ b/test/whitelist.js
@@ -23,7 +23,7 @@ const ERC20 = artifacts.require("TestERC20");
 const utils = require("../utils/utilities.js");
 const { ETH_TOKEN, encodeTransaction, addTrustedContact, initNonce } = require("../utils/utilities.js");
 
-const ZERO_BYTES32 = ethers.constants.HashZero;
+const ZERO_BYTES = "0x";
 const ZERO_ADDRESS = ethers.constants.AddressZero;
 const SECURITY_PERIOD = 2;
 const SECURITY_WINDOW = 2;
@@ -142,7 +142,7 @@ contract("ArgentModule", (accounts) => {
       await addTrustedContact(wallet, recipient, module, SECURITY_PERIOD);
       const balanceStart = await utils.getBalance(recipient);
 
-      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES32);
+      const transaction = encodeTransaction(recipient, 10, ZERO_BYTES);
 
       const txReceipt = await manager.relay(
         module,

--- a/truffle-config-modules.js
+++ b/truffle-config-modules.js
@@ -11,7 +11,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 800,
+          runs: 560,
         },
       },
     },

--- a/utils/utilities.js
+++ b/utils/utilities.js
@@ -5,7 +5,7 @@ const chai = require("chai");
 
 const { assert, expect } = chai;
 const ETH_TOKEN = ethers.constants.AddressZero;
-const ZERO_BYTES32 = ethers.constants.HashZero;
+const ZERO_BYTES = "0x";
 
 const utilities = {
 
@@ -273,7 +273,7 @@ const utilities = {
     const nonceInitialiser = await utilities.getAccount(8);
     await utilities.addTrustedContact(wallet, nonceInitialiser, module, securityPeriod);
     const owner = await wallet.owner();
-    const transaction = utilities.encodeTransaction(nonceInitialiser, 1, ZERO_BYTES32);
+    const transaction = utilities.encodeTransaction(nonceInitialiser, 1, ZERO_BYTES);
     await manager.relay(
       module,
       "multiCall",

--- a/utils/utilities.js
+++ b/utils/utilities.js
@@ -258,7 +258,7 @@ const utilities = {
     throw new Error(`Invalid method "${method}"`);
   },
 
-  encodeTransaction: (to, value, data, isTokenCall = false) => ({ to, value, data, isTokenCall }),
+  encodeTransaction: (to, value, data) => ({ to, value, data }),
 
   addTrustedContact: async (wallet, target, module, securityPeriod) => {
     const owner = await wallet.owner();


### PR DESCRIPTION
Changing the logic by which the spender is recovered to match transaction[i].data with ERC20 methods instead of using `transaction[i].isTokenCall`

Note: being able to fit in spender recovery support for ERC721 methods requires further bytecode reduction. Temporarily achieved via a reduction of the number of runs from 800 to 560.