### PR TITLE
Fix legacy wallet factory

### DIFF
--- a/contracts/infrastructure/ens/ArgentENSManager.sol
+++ b/contracts/infrastructure/ens/ArgentENSManager.sol
@@ -66,8 +66,7 @@ contract ArgentENSManager is IENSManager, Owned, Managed {
     // *************** External Functions ********************* //
 
     /**
-     * @notice This function must be called when the ENS Manager contract is replaced and the address of the new Manager should be provided.
-     * @param _newOwner The address of the new ENS manager that will manage the root node.
+     * @inheritdoc IENSManager
      */
     function changeRootnodeOwner(address _newOwner) external override onlyOwner {
         ensRegistry.setOwner(rootNode, _newOwner);
@@ -85,16 +84,23 @@ contract ArgentENSManager is IENSManager, Owned, Managed {
     }
 
     /**
-    * @notice Lets the manager assign an ENS subdomain of the root node to a target address.
-    * Registers both the forward and reverse ENS.
-    * @param _label The subdomain label.
-    * @param _owner The owner of the subdomain.
-    * @param _managerSignature The manager signature of the hash of _owner and _label.
-    */
+     * @inheritdoc IENSManager
+     */
     function register(string calldata _label, address _owner, bytes calldata _managerSignature) external override validateENSLabel(_label) {
         bytes32 signedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", keccak256(abi.encodePacked(_owner, _label))));
         validateManagerSignature(signedHash, _managerSignature);
 
+        _register(_label, _owner);
+    }
+
+    /**
+     * @inheritdoc IENSManager
+     */
+    function register(string calldata _label, address _owner) external override onlyManager validateENSLabel(_label) {
+        _register(_label, _owner);
+    }
+
+    function _register(string calldata _label, address _owner) internal {
         bytes32 labelNode = keccak256(abi.encodePacked(_label));
         bytes32 node = keccak256(abi.encodePacked(rootNode, labelNode));
         address currentOwner = ensRegistry.owner(node);
@@ -132,9 +138,8 @@ contract ArgentENSManager is IENSManager, Owned, Managed {
     }
 
     /**
-    * @notice Gets the official ENS reverse registrar.
-    * @return Address of the ENS reverse registrar.
-    */
+     * @inheritdoc IENSManager
+     */
     function getENSReverseRegistrar() external view override returns (address) {
         return _getENSReverseRegistrar();
     }
@@ -142,9 +147,7 @@ contract ArgentENSManager is IENSManager, Owned, Managed {
     // *************** Public Functions ********************* //
 
     /**
-     * @notice Returns true is a given subnode is available.
-     * @param _subnode The target subnode.
-     * @return true if the subnode is available.
+     * @inheritdoc IENSManager
      */
     function isAvailable(bytes32 _subnode) public view override returns (bool) {
         bytes32 node = keccak256(abi.encodePacked(rootNode, _subnode));

--- a/contracts/infrastructure/ens/ArgentENSManager.sol
+++ b/contracts/infrastructure/ens/ArgentENSManager.sol
@@ -42,8 +42,7 @@ contract ArgentENSManager is IENSManager, Owned, Managed {
 
 
    modifier validateENSLabel(string memory _label) {
-      bytes memory labelBytes = bytes(_label);
-      require(labelBytes.length != 0, "AEM: ENS label must be defined");
+      require(bytes(_label).length != 0, "AEM: ENS label must be defined");
       _;
     }
 

--- a/contracts/infrastructure/ens/IENSManager.sol
+++ b/contracts/infrastructure/ens/IENSManager.sol
@@ -34,12 +34,21 @@ interface IENSManager {
 
     /**
     * @notice Lets the manager assign an ENS subdomain of the root node to a target address.
-    * Registers both the forward and reverse ENS.
+    * Registers forward ENS and optionally reverse ENS.
     * @param _label The subdomain label.
     * @param _owner The owner of the subdomain.
     * @param _managerSignature The manager signature of the hash of _owner and _label.
     */
     function register(string calldata _label, address _owner, bytes calldata _managerSignature) external;
+
+    /**
+    * @notice Backward compatible overload for WalletFactory 1.6
+    * Lets the manager assign an ENS subdomain of the root node to a target address.
+    * Registers forward ENS and optionally reverse ENS.
+    * @param _label The subdomain label.
+    * @param _owner The owner of the subdomain.
+    */
+    function register(string calldata _label, address _owner) external;
 
     /**
      * @notice Returns true is a given subnode is available.

--- a/deployment/8_update_ens.js
+++ b/deployment/8_update_ens.js
@@ -16,6 +16,9 @@ async function main() {
   const { deploymentAccount, configurator, abiUploader } = await deployManager.getProps();
   const { config } = configurator;
   const { domain } = config.ENS;
+  // ENVIRONMENT SPECIFIC
+  // ROPSTEN
+  const walletFactoryVersion16 = "0x802248Ec4d68879Ce62d33748776Db5a1a98C422";
 
   // Instantiate the ENS Registry and existing ENSManager
   const ENSManagerWrapper = await ENSManager.at(config.contracts.ENSManager);
@@ -40,6 +43,9 @@ async function main() {
     console.log(`Set ${account} as the manager of the WalletFactory`);
     await NewENSManagerWrapper.addManager(account);
   }
+
+  // The legacy factory has to be a manager of the new ENSManager as it calls it's register function for new wallets
+  await NewENSManagerWrapper.addManager(walletFactoryVersion16);
 
   // Set the MultiSig as the owner of the new ENSManager
   await NewENSManagerWrapper.changeOwner(config.contracts.MultiSigWallet);

--- a/test/ens.js
+++ b/test/ens.js
@@ -122,7 +122,8 @@ contract("ENS contracts", (accounts) => {
       ].map((hex) => hex.slice(2)).join("")}`;
       const managerSig = await utilities.signMessage(ethers.utils.keccak256(message), infrastructure);
 
-      await ensManager.register(label, owner, managerSig, { from: anonmanager });
+      const data = await ensManager.contract.methods["register(string,address,bytes)"](label, owner, managerSig).encodeABI();
+      await ensManager.sendTransaction({ data, from: anonmanager });
 
       const recordExists = await ensRegistry.recordExists(labelNode);
       assert.isTrue(recordExists);
@@ -151,7 +152,8 @@ contract("ENS contracts", (accounts) => {
       ].map((hex) => hex.slice(2)).join("")}`;
       const managerSig = await utilities.signMessage(ethers.utils.keccak256(message), infrastructure);
 
-      await ensManager.register(label, owner, managerSig, { from: anonmanager });
+      const data = await ensManager.contract.methods["register(string,address,bytes)"](label, owner, managerSig).encodeABI();
+      await ensManager.sendTransaction({ data, from: anonmanager });
 
       // check ens record
       const recordExists = await ensRegistry.recordExists(labelNode);
@@ -190,14 +192,17 @@ contract("ENS contracts", (accounts) => {
       const label = "wallet";
       const labelNode = ethers.utils.namehash(`${label}.${subnameWallet}.${root}`);
       await ensManager.addManager(amanager);
-      await ensManager.register(label, owner, "0x", { from: amanager });
+      const data = await ensManager.contract.methods["register(string,address,bytes)"](label, owner, "0x").encodeABI();
+      await ensManager.sendTransaction({ data, from: amanager });
+
       const nodeOwner = await ensRegistry.owner(labelNode);
       assert.equal(nodeOwner, owner, "new manager should have registered the ens name");
     });
 
     it("should fail to register an ENS name when the caller is not a manager", async () => {
       const label = "wallet";
-      await truffleAssert.reverts(ensManager.register(label, owner, "0x", { from: anonmanager }), "AEM: user is not manager");
+      const data = await ensManager.contract.methods["register(string,address,bytes)"](label, owner, "0x").encodeABI();
+      await truffleAssert.reverts(ensManager.sendTransaction({ data, from: anonmanager }), "AEM: user is not manager");
     });
 
     it("should be able to change the root node owner", async () => {


### PR DESCRIPTION
Overload `ArgentENSManager.register` function to fix legacy factory integration. 

Update deployment script to set legacy wallet factory as manager of new `ArgentENSManager`