### PR TITLE
Optimise guardian validation logic

### DIFF
--- a/contracts/modules/RelayerManager.sol
+++ b/contracts/modules/RelayerManager.sol
@@ -263,10 +263,6 @@ abstract contract RelayerManager is BaseModule, SimpleOracle {
             return true;
         }
         address lastSigner = address(0);
-        address[] memory guardians;
-        if (_option != OwnerSignature.Required || _signatures.length > 65) {
-            guardians = guardianStorage.getGuardians(_wallet); // guardians are only read if they may be needed
-        }
 
         for (uint256 i = 0; i < _signatures.length / 65; i++) {
             address signer = Utils.recoverSigner(_signHash, _signatures, i);
@@ -289,7 +285,7 @@ abstract contract RelayerManager is BaseModule, SimpleOracle {
                 return false; // Signers must be different
             }
             lastSigner = signer;
-            bool isGuardian = _isGuardianOrGuardianSigner(guardians, signer);
+            bool isGuardian = _isGuardianOrGuardianSigner(_wallet, signer);
             if (!isGuardian) {
                 return false;
             }

--- a/contracts/modules/RelayerManager.sol
+++ b/contracts/modules/RelayerManager.sol
@@ -18,7 +18,6 @@ pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/Math.sol";
-import "./common/Utils.sol";
 import "./common/BaseModule.sol";
 import "./common/SimpleOracle.sol";
 import "../infrastructure/storage/IGuardianStorage.sol";
@@ -290,7 +289,7 @@ abstract contract RelayerManager is BaseModule, SimpleOracle {
                 return false; // Signers must be different
             }
             lastSigner = signer;
-            bool isGuardian = Utils.isGuardianOrGuardianSigner(guardians, signer);
+            bool isGuardian = _isGuardianOrGuardianSigner(guardians, signer);
             if (!isGuardian) {
                 return false;
             }

--- a/contracts/modules/RelayerManager.sol
+++ b/contracts/modules/RelayerManager.sol
@@ -268,7 +268,6 @@ abstract contract RelayerManager is BaseModule, SimpleOracle {
         if (_option != OwnerSignature.Required || _signatures.length > 65) {
             guardians = guardianStorage.getGuardians(_wallet); // guardians are only read if they may be needed
         }
-        bool isGuardian;
 
         for (uint256 i = 0; i < _signatures.length / 65; i++) {
             address signer = Utils.recoverSigner(_signHash, _signatures, i);
@@ -291,7 +290,7 @@ abstract contract RelayerManager is BaseModule, SimpleOracle {
                 return false; // Signers must be different
             }
             lastSigner = signer;
-            (isGuardian, guardians) = Utils.isGuardianOrGuardianSigner(guardians, signer);
+            bool isGuardian = Utils.isGuardianOrGuardianSigner(guardians, signer);
             if (!isGuardian) {
                 return false;
             }

--- a/contracts/modules/SecurityManager.sol
+++ b/contracts/modules/SecurityManager.sol
@@ -17,7 +17,6 @@
 pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/utils/SafeCast.sol";
-import "./common/Utils.sol";
 import "./common/BaseModule.sol";
 import "../wallet/IWallet.sol";
 
@@ -351,7 +350,7 @@ abstract contract SecurityManager is BaseModule {
     * @return _isGuardian `true` if the address is a guardian for the wallet otherwise `false`.
     */
     function isGuardianOrGuardianSigner(address _wallet, address _user) external view returns (bool _isGuardian) {
-        return Utils.isGuardianOrGuardianSigner(guardianStorage.getGuardians(_wallet), _user);
+        return _isGuardianOrGuardianSigner(guardianStorage.getGuardians(_wallet), _user);
     }
 
     /**

--- a/contracts/modules/SecurityManager.sol
+++ b/contracts/modules/SecurityManager.sol
@@ -347,11 +347,11 @@ abstract contract SecurityManager is BaseModule {
     /**
     * @notice Checks if an address is a guardian or an account authorised to sign on behalf of a smart-contract guardian.
     * @param _wallet The target wallet.
-    * @param _guardian the address to test
+    * @param _user the address to test
     * @return _isGuardian `true` if the address is a guardian for the wallet otherwise `false`.
     */
-    function isGuardianOrGuardianSigner(address _wallet, address _guardian) external view returns (bool _isGuardian) {
-        return Utils.isGuardianOrGuardianSigner(guardianStorage.getGuardians(_wallet), _guardian);
+    function isGuardianOrGuardianSigner(address _wallet, address _user) external view returns (bool _isGuardian) {
+        return Utils.isGuardianOrGuardianSigner(guardianStorage.getGuardians(_wallet), _user);
     }
 
     /**

--- a/contracts/modules/SecurityManager.sol
+++ b/contracts/modules/SecurityManager.sol
@@ -350,7 +350,7 @@ abstract contract SecurityManager is BaseModule {
     * @return _isGuardian `true` if the address is a guardian for the wallet otherwise `false`.
     */
     function isGuardianOrGuardianSigner(address _wallet, address _user) external view returns (bool _isGuardian) {
-        return _isGuardianOrGuardianSigner(guardianStorage.getGuardians(_wallet), _user);
+        return _isGuardianOrGuardianSigner(_wallet, _user);
     }
 
     /**

--- a/contracts/modules/SecurityManager.sol
+++ b/contracts/modules/SecurityManager.sol
@@ -351,7 +351,7 @@ abstract contract SecurityManager is BaseModule {
     * @return _isGuardian `true` if the address is a guardian for the wallet otherwise `false`.
     */
     function isGuardianOrGuardianSigner(address _wallet, address _guardian) external view returns (bool _isGuardian) {
-        (_isGuardian, ) = Utils.isGuardianOrGuardianSigner(guardianStorage.getGuardians(_wallet), _guardian);
+        return Utils.isGuardianOrGuardianSigner(guardianStorage.getGuardians(_wallet), _guardian);
     }
 
     /**

--- a/contracts/modules/TransactionManager.sol
+++ b/contracts/modules/TransactionManager.sol
@@ -18,7 +18,6 @@ pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/utils/SafeCast.sol";
-import "./common/Utils.sol";
 import "./common/BaseModule.sol";
 import "../../lib/other/ERC20.sol";
 

--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -173,23 +173,25 @@ abstract contract BaseModule is IModule {
     /**
     * @notice Checks if an address is a guardian or an account authorised to sign on behalf of a smart-contract guardian
     * given a list of guardians.
-    * @param _guardians the list of guardians
+    * @param _wallet the wallet address
     * @param _user the address to test
     */
-    function _isGuardianOrGuardianSigner(address[] memory _guardians, address _user) internal view returns (bool) {
-        if (_guardians.length == 0 || _user == address(0)) {
+    function _isGuardianOrGuardianSigner(address _wallet, address _user) internal view returns (bool) {
+        address[] memory guardians = guardianStorage.getGuardians(_wallet);
+
+        if (guardians.length == 0 || _user == address(0)) {
             return false;
         }
         bool isFound = false;
-        for (uint256 i = 0; i < _guardians.length; i++) {
+        for (uint256 i = 0; i < guardians.length; i++) {
             if (!isFound) {
                 // check if _user is an account guardian
-                if (_user == _guardians[i]) {
+                if (_user == guardians[i]) {
                     isFound = true;
                     continue;
                 }
                 // check if _user is the owner of a smart contract guardian
-                if (Utils.isContract(_guardians[i]) && Utils.isGuardianOwner(_guardians[i], _user)) {
+                if (Utils.isContract(guardians[i]) && Utils.isGuardianOwner(guardians[i], _user)) {
                     isFound = true;
                     continue;
                 }

--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -23,6 +23,7 @@ import "../../infrastructure/storage/IGuardianStorage.sol";
 import "../../infrastructure/IAuthoriser.sol";
 import "../../infrastructure/storage/ITransferStorage.sol";
 import "./IModule.sol";
+import "./Utils.sol";
 import "../../../lib/other/ERC20.sol";
 
 /**
@@ -166,6 +167,35 @@ abstract contract BaseModule is IModule {
      */
     function _isSelf(address _addr) internal view returns (bool) {
         return _addr == address(this);
+    }
+
+
+    /**
+    * @notice Checks if an address is a guardian or an account authorised to sign on behalf of a smart-contract guardian
+    * given a list of guardians.
+    * @param _guardians the list of guardians
+    * @param _user the address to test
+    */
+    function _isGuardianOrGuardianSigner(address[] memory _guardians, address _user) internal view returns (bool) {
+        if (_guardians.length == 0 || _user == address(0)) {
+            return false;
+        }
+        bool isFound = false;
+        for (uint256 i = 0; i < _guardians.length; i++) {
+            if (!isFound) {
+                // check if _user is an account guardian
+                if (_user == _guardians[i]) {
+                    isFound = true;
+                    continue;
+                }
+                // check if _user is the owner of a smart contract guardian
+                if (Utils.isContract(_guardians[i]) && Utils.isGuardianOwner(_guardians[i], _user)) {
+                    isFound = true;
+                    continue;
+                }
+            }
+        }
+        return isFound;
     }
 
     /**

--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -191,7 +191,7 @@ abstract contract BaseModule is IModule {
                     continue;
                 }
                 // check if _user is the owner of a smart contract guardian
-                if (Utils.isContract(guardians[i]) && Utils.isGuardianOwner(guardians[i], _user)) {
+                if (Utils.isContract(guardians[i]) && Utils.isContractOwner(guardians[i], _user)) {
                     isFound = true;
                     continue;
                 }

--- a/contracts/modules/common/Utils.sol
+++ b/contracts/modules/common/Utils.sol
@@ -77,15 +77,12 @@ library Utils {
     * given a list of guardians.
     * @param _guardians the list of guardians
     * @param _guardian the address to test
-    * @return true and the list of guardians minus the found guardian upon success, false and the original list of guardians if not found.
     */
-    function isGuardianOrGuardianSigner(address[] memory _guardians, address _guardian) internal view returns (bool, address[] memory) {
+    function isGuardianOrGuardianSigner(address[] memory _guardians, address _guardian) internal view returns (bool) {
         if (_guardians.length == 0 || _guardian == address(0)) {
             return (false, _guardians);
         }
         bool isFound = false;
-        address[] memory updatedGuardians = new address[](_guardians.length - 1);
-        uint256 index = 0;
         for (uint256 i = 0; i < _guardians.length; i++) {
             if (!isFound) {
                 // check if _guardian is an account guardian
@@ -99,12 +96,8 @@ library Utils {
                     continue;
                 }
             }
-            if (index < updatedGuardians.length) {
-                updatedGuardians[index] = _guardians[i];
-                index++;
-            }
         }
-        return isFound ? (true, updatedGuardians) : (false, _guardians);
+        return isFound;
     }
 
     /**

--- a/contracts/modules/common/Utils.sol
+++ b/contracts/modules/common/Utils.sol
@@ -73,12 +73,12 @@ library Utils {
     }
 
     /**
-    * @notice Checks if an address is the owner of a guardian contract.
+    * @notice Checks if an address is the owner of a contract.
     * The method does not revert if the call to the owner() method consumes more then 5000 gas.
     * @param _contract The contract to check
     * @param _owner The owner to verify.
     */
-    function isGuardianOwner(address _contract, address _owner) internal view returns (bool) {
+    function isContractOwner(address _contract, address _owner) internal view returns (bool) {
         address owner = address(0);
         bytes4 sig = bytes4(keccak256("owner()"));
 

--- a/contracts/modules/common/Utils.sol
+++ b/contracts/modules/common/Utils.sol
@@ -76,22 +76,22 @@ library Utils {
     * @notice Checks if an address is a guardian or an account authorised to sign on behalf of a smart-contract guardian
     * given a list of guardians.
     * @param _guardians the list of guardians
-    * @param _guardian the address to test
+    * @param _user the address to test
     */
-    function isGuardianOrGuardianSigner(address[] memory _guardians, address _guardian) internal view returns (bool) {
-        if (_guardians.length == 0 || _guardian == address(0)) {
+    function isGuardianOrGuardianSigner(address[] memory _guardians, address _user) internal view returns (bool) {
+        if (_guardians.length == 0 || _user == address(0)) {
             return (false, _guardians);
         }
         bool isFound = false;
         for (uint256 i = 0; i < _guardians.length; i++) {
             if (!isFound) {
-                // check if _guardian is an account guardian
-                if (_guardian == _guardians[i]) {
+                // check if _user is an account guardian
+                if (_user == _guardians[i]) {
                     isFound = true;
                     continue;
                 }
-                // check if _guardian is the owner of a smart contract guardian
-                if (isContract(_guardians[i]) && isGuardianOwner(_guardians[i], _guardian)) {
+                // check if _user is the owner of a smart contract guardian
+                if (isContract(_guardians[i]) && isGuardianOwner(_guardians[i], _user)) {
                     isFound = true;
                     continue;
                 }
@@ -103,10 +103,10 @@ library Utils {
     /**
     * @notice Checks if an address is the owner of a guardian contract.
     * The method does not revert if the call to the owner() method consumes more then 5000 gas.
-    * @param _guardian The guardian contract
+    * @param _contract The contract to check
     * @param _owner The owner to verify.
     */
-    function isGuardianOwner(address _guardian, address _owner) internal view returns (bool) {
+    function isGuardianOwner(address _contract, address _owner) internal view returns (bool) {
         address owner = address(0);
         bytes4 sig = bytes4(keccak256("owner()"));
 
@@ -114,7 +114,7 @@ library Utils {
         assembly {
             let ptr := mload(0x40)
             mstore(ptr,sig)
-            let result := staticcall(5000, _guardian, ptr, 0x20, ptr, 0x20)
+            let result := staticcall(5000, _contract, ptr, 0x20, ptr, 0x20)
             if eq(result, 1) {
                 owner := mload(ptr)
             }

--- a/contracts/modules/common/Utils.sol
+++ b/contracts/modules/common/Utils.sol
@@ -73,34 +73,6 @@ library Utils {
     }
 
     /**
-    * @notice Checks if an address is a guardian or an account authorised to sign on behalf of a smart-contract guardian
-    * given a list of guardians.
-    * @param _guardians the list of guardians
-    * @param _user the address to test
-    */
-    function isGuardianOrGuardianSigner(address[] memory _guardians, address _user) internal view returns (bool) {
-        if (_guardians.length == 0 || _user == address(0)) {
-            return (false, _guardians);
-        }
-        bool isFound = false;
-        for (uint256 i = 0; i < _guardians.length; i++) {
-            if (!isFound) {
-                // check if _user is an account guardian
-                if (_user == _guardians[i]) {
-                    isFound = true;
-                    continue;
-                }
-                // check if _user is the owner of a smart contract guardian
-                if (isContract(_guardians[i]) && isGuardianOwner(_guardians[i], _user)) {
-                    isFound = true;
-                    continue;
-                }
-            }
-        }
-        return isFound;
-    }
-
-    /**
     * @notice Checks if an address is the owner of a guardian contract.
     * The method does not revert if the call to the owner() method consumes more then 5000 gas.
     * @param _contract The contract to check


### PR DESCRIPTION
Slightly cleaner guardian validation logic in that guardians are looked up inside the `_isGuardianOrGuardianSigner` function instead of being passed to it. Also makes property names clearer. 