### PR TITLE
Change optimisation runs to 400 for modules

### DIFF
--- a/contracts-test/TestFilter.sol
+++ b/contracts-test/TestFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/DappRegistry.sol
+++ b/contracts/infrastructure/DappRegistry.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/IAuthoriser.sol
+++ b/contracts/infrastructure/IAuthoriser.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/AaveV2Filter.sol
+++ b/contracts/infrastructure/dapp/AaveV2Filter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/BalancerFilter.sol
+++ b/contracts/infrastructure/dapp/BalancerFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/BaseFilter.sol
+++ b/contracts/infrastructure/dapp/BaseFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/CompoundCTokenFilter.sol
+++ b/contracts/infrastructure/dapp/CompoundCTokenFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/IFilter.sol
+++ b/contracts/infrastructure/dapp/IFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/OnlyApproveFilter.sol
+++ b/contracts/infrastructure/dapp/OnlyApproveFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/ParaswapFilter.sol
+++ b/contracts/infrastructure/dapp/ParaswapFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/UniswapV2UniZapFilter.sol
+++ b/contracts/infrastructure/dapp/UniswapV2UniZapFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/YearnFilter.sol
+++ b/contracts/infrastructure/dapp/YearnFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/dsr/DaiJoinFilter.sol
+++ b/contracts/infrastructure/dapp/dsr/DaiJoinFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/dsr/PotFilter.sol
+++ b/contracts/infrastructure/dapp/dsr/PotFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/infrastructure/dapp/dsr/VatFilter.sol
+++ b/contracts/infrastructure/dapp/dsr/VatFilter.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/modules/ArgentModule.sol
+++ b/contracts/modules/ArgentModule.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/modules/common/BaseModule.sol
+++ b/contracts/modules/common/BaseModule.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/contracts/modules/common/SimpleOracle.sol
+++ b/contracts/modules/common/SimpleOracle.sol
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.s
+// GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -247,6 +247,8 @@ contract("ArgentModule", (accounts) => {
       assert.isTrue(success, "transfer failed");
       const balanceEnd = await utils.getBalance(wallet.address);
       expect(balanceEnd.sub(balanceStart)).to.be.lt.BN(0);
+
+      console.log("Gas for relaying an ERC20 transfer with refund in ETH:", txReceipt.gasUsed);
     });
 
     it("should refund in ERC20", async () => {
@@ -267,6 +269,8 @@ contract("ArgentModule", (accounts) => {
       assert.isTrue(success, "transfer failed");
       const balanceEnd = await token.balanceOf(relayer);
       expect(balanceEnd.sub(balanceStart)).to.be.gt.BN(0);
+
+      console.log("Gas for relaying an ETH transfer with refund in ERC20:", txReceipt.gasUsed);
     });
 
     it("should emit the Refund event", async () => {

--- a/truffle-config-infrastructure.js
+++ b/truffle-config-infrastructure.js
@@ -11,7 +11,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 999,
+          runs: 200,
         },
       },
     },

--- a/truffle-config-infrastructure.js
+++ b/truffle-config-infrastructure.js
@@ -11,7 +11,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 200,
+          runs: 999,
         },
       },
     },

--- a/truffle-config-modules.js
+++ b/truffle-config-modules.js
@@ -11,7 +11,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 200,
+          runs: 400,
         },
       },
     },

--- a/truffle-config-modules.js
+++ b/truffle-config-modules.js
@@ -11,7 +11,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 560,
+          runs: 200,
         },
       },
     },


### PR DESCRIPTION
Due to the limit of contract size to `24,576` bytes, introduced by [EIP-170](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md) we have had to lower our optimisation runs for the modules from 999 to 560 as `ArgentModule` was exceeding that limit at higher runs. Here we experimented with different optimisation settings to measure how that affected bytecode size and gas costs.

| Optimisation runs                                     | 560     | [500](https://app.circleci.com/pipelines/github/argentlabs/argent-contracts/1984/workflows/7087bca2-432c-4777-9fed-cd13f9b37f79/jobs/2331)    | [400](https://app.circleci.com/pipelines/github/argentlabs/argent-contracts/1985/workflows/b9dcceb5-29c4-4cf7-a0af-32d25755b8ee/jobs/2332)    | [300](https://app.circleci.com/pipelines/github/argentlabs/argent-contracts/1986/workflows/59ee4cf7-6e48-4bf7-b570-5d36404c6517/jobs/2333)    | [200](https://app.circleci.com/pipelines/github/argentlabs/argent-contracts/1982/workflows/27c9dbd2-1d0d-4aa2-bafa-4df971ce04e2)     |
|-------------------------------------------------------|---------|--------|--------|--------|---------|
| ArgentModule bytecode size                                 | 24,470  | 24,470 (0) | 24,416 (-54) | 24,284 (-186) | 24,244 (-226)  |
| Gas for relaying an ERC20 transfer with refund in ETH | 124,436 |  124,441 (+5)      |   124,436 (0)    |   124,424  (-12)   | 124,457 (+21) |
| Gas for relaying an ETH transfer with refund in ERC20 | 128,620 |   128,637 (+17)     |    128,620 (0)    |  128,683 (+63)     | 128,699 (+79) |