### PR TITLE
Extend MultiCallHelper with isAuthorisedInRegistry function

### DIFF
--- a/contracts/infrastructure/DappRegistry.sol
+++ b/contracts/infrastructure/DappRegistry.sol
@@ -45,7 +45,7 @@ contract DappRegistry is IAuthoriser {
     event FilterUpdateRequested(uint8 indexed registryId, address dapp, address filter, uint256 validAfter);
     event DappAdded(uint8 indexed registryId, address dapp, address filter, uint256 validAfter);
     event DappRemoved(uint8 indexed registryId, address dapp);
-    event ToggledRegistry(address sender, uint8 registryId, bool enabled);
+    event ToggledRegistry(address indexed sender, uint8 registryId, bool enabled);
 
     modifier onlyOwner(uint8 _registryId) {
         validateOwner(_registryId);


### PR DESCRIPTION
- Adds a  new helper function for the clients with the following signature: `isAuthorisedInRegistry(address _wallet, Call[] calldata _transactions, uint8 _registryId)` which returns `boolean` of whether all the transactions are authorised in the given registry
-  Makes the `sender` event param in `ToggledRegistry` event indexed