### PR TITLE
Aave V1 filter

### DIFF
--- a/contracts/infrastructure/dapp/AaveETHTokenFilter.sol
+++ b/contracts/infrastructure/dapp/AaveETHTokenFilter.sol
@@ -1,0 +1,30 @@
+// Copyright (C) 2021  Argent Labs Ltd. <https://argent.xyz>
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.6.12;
+
+import "./BaseFilter.sol";
+
+contract AaveETHTokenFilter is BaseFilter {
+
+    bytes4 private constant REDEEM = bytes4(keccak256("redeem(uint256)"));
+
+    function isValid(address /*_wallet*/, address /*_spender*/, address /*_to*/, bytes calldata _data) external view override returns (bool) {
+        bytes4 method = getMethod(_data);
+
+        return (method == REDEEM);
+    }
+}

--- a/contracts/infrastructure/dapp/AaveV1ATokenFilter.sol
+++ b/contracts/infrastructure/dapp/AaveV1ATokenFilter.sol
@@ -18,7 +18,7 @@ pragma solidity ^0.6.12;
 
 import "./BaseFilter.sol";
 
-contract AaveETHTokenFilter is BaseFilter {
+contract AaveV1ATokenFilter is BaseFilter {
 
     bytes4 private constant REDEEM = bytes4(keccak256("redeem(uint256)"));
 

--- a/contracts/infrastructure/dapp/AaveV1Filter.sol
+++ b/contracts/infrastructure/dapp/AaveV1Filter.sol
@@ -18,7 +18,7 @@ pragma solidity ^0.6.12;
 
 import "./BaseFilter.sol";
 
-contract AaveV1Filter is BaseFilter {
+contract AaveV1LendingPoolFilter is BaseFilter {
 
     bytes4 private constant DEPOSIT = bytes4(keccak256("deposit(address,uint256,uint16)"));
 

--- a/contracts/infrastructure/dapp/AaveV1Filter.sol
+++ b/contracts/infrastructure/dapp/AaveV1Filter.sol
@@ -1,0 +1,30 @@
+// Copyright (C) 2021  Argent Labs Ltd. <https://argent.xyz>
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.6.12;
+
+import "./BaseFilter.sol";
+
+contract AaveV1Filter is BaseFilter {
+
+    bytes4 private constant DEPOSIT = bytes4(keccak256("deposit(address,uint256,uint16)"));
+
+    function isValid(address /*_wallet*/, address /*_spender*/, address /*_to*/, bytes calldata _data) external view override returns (bool) {
+        bytes4 method = getMethod(_data);
+
+        return (method == DEPOSIT);
+    }
+}

--- a/deployment/7_deploy_2.5.js
+++ b/deployment/7_deploy_2.5.js
@@ -31,8 +31,8 @@ const ScdMcdMigration = artifacts.require("ScdMcdMigration");
 const UniswapV2Filter = artifacts.require("UniswapV2UniZapFilter");
 const LidoFilter = artifacts.require("LidoFilter");
 const CurveFilter = artifacts.require("CurveFilter");
-const AaveV1Filter = artifacts.require("AaveV1Filter");
-const AaveETHTokenFilter = artifacts.require("AaveETHTokenFilter");
+const AaveV1LendingPoolFilter = artifacts.require("AaveV1LendingPoolFilter");
+const AaveV1ATokenFilter = artifacts.require("AaveV1ATokenFilter");
 
 const deployManager = require("../utils/deploy-manager.js");
 const MultisigExecutor = require("../utils/multisigexecutor.js");
@@ -212,13 +212,19 @@ const main = async () => {
 
   // Aave V1
   console.log("Deploying AaveV1");
-  const AaveV1FilterWrapper = await AaveV1Filter.new();
-  console.log(`Deployed AaveV1Filter at ${AaveV1FilterWrapper.address}`);
-  await DappRegistryWrapper.addDapp(0, config.defi.aave.lendingPool, AaveV1FilterWrapper.address);
 
-  const AaveETHTokenFilterWrapper = await AaveETHTokenFilter.new();
-  console.log(`Deployed AaveETHTokenFilter at ${AaveETHTokenFilterWrapper.address}`);
-  await DappRegistryWrapper.addDapp(0, config.defi.aave.aaveToken, AaveETHTokenFilterWrapper.address);
+  const AaveV1LendingPoolFilterWrapper = await AaveV1LendingPoolFilter.new();
+  console.log(`Deployed AaveV1LendingPoolFilter at ${AaveV1LendingPoolFilterWrapper.address}`);
+  await DappRegistryWrapper.addDapp(0, config.defi.aave.lendingPool, AaveV1LendingPoolFilterWrapper.address);
+  console.log("Adding OnlyApproveFilter for AavelendingPoolCore");
+  await DappRegistryWrapper.addDapp(0, config.defi.aave.lendingPoolCore, OnlyApproveFilterWrapper.address);
+
+  const AaveV1ATokenFilterWrapper = await AaveV1ATokenFilter.new();
+  console.log(`Deployed AaveV1ATokenFilter at ${AaveV1ATokenFilterWrapper.address}`);
+  for (const aToken of (config.defi.aave.aTokens)) {
+    console.log(`Adding filter for Aave token ${aToken}`);
+    await DappRegistryWrapper.addDapp(0, aToken, AaveV1ATokenFilterWrapper.address);
+  }
 
   // Setting timelock
   console.log(`Setting Timelock to ${config.settings.timelockPeriod}`);

--- a/deployment/7_deploy_2.5.js
+++ b/deployment/7_deploy_2.5.js
@@ -31,6 +31,8 @@ const ScdMcdMigration = artifacts.require("ScdMcdMigration");
 const UniswapV2Filter = artifacts.require("UniswapV2UniZapFilter");
 const LidoFilter = artifacts.require("LidoFilter");
 const CurveFilter = artifacts.require("CurveFilter");
+const AaveV1Filter = artifacts.require("AaveV1Filter");
+const AaveETHTokenFilter = artifacts.require("AaveETHTokenFilter");
 
 const deployManager = require("../utils/deploy-manager.js");
 const MultisigExecutor = require("../utils/multisigexecutor.js");
@@ -207,6 +209,16 @@ const main = async () => {
   const UniswapV2FilterWrapper = await UniswapV2Filter.new();
   console.log(`Deployed UniswapV2Filter at ${UniswapV2FilterWrapper.address}`);
   await DappRegistryWrapper.addDapp(0, config.defi.uniswap.unizap, UniswapV2FilterWrapper.address);
+
+  // Aave V1
+  console.log("Deploying AaveV1");
+  const AaveV1FilterWrapper = await AaveV1Filter.new();
+  console.log(`Deployed AaveV1Filter at ${AaveV1FilterWrapper.address}`);
+  await DappRegistryWrapper.addDapp(0, config.defi.aave.lendingPool, AaveV1FilterWrapper.address);
+
+  const AaveETHTokenFilterWrapper = await AaveETHTokenFilter.new();
+  console.log(`Deployed AaveETHTokenFilter at ${AaveETHTokenFilterWrapper.address}`);
+  await DappRegistryWrapper.addDapp(0, config.defi.aave.aaveToken, AaveETHTokenFilterWrapper.address);
 
   // Setting timelock
   console.log(`Setting Timelock to ${config.settings.timelockPeriod}`);

--- a/lib/aaveV1/IAToken.sol
+++ b/lib/aaveV1/IAToken.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.5.4;
+
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title Aave ERC20 AToken
+ *
+ * @dev Implementation of the interest bearing token for the DLP protocol.
+ * https://etherscan.io/address/0x3a3A65aAb0dd2A17E3F1947bA16138cd37d08c04#code
+ * @author Aave
+ */
+ contract IAToken is IERC20 {
+    /**
+    * @dev emitted after the redeem action
+    * @param _from the address performing the redeem
+    * @param _value the amount to be redeemed
+    * @param _fromBalanceIncrease the cumulated balance since the last update of the user
+    * @param _fromIndex the last index of the user
+    **/
+    event Redeem(
+        address indexed _from,
+        uint256 _value,
+        uint256 _fromBalanceIncrease,
+        uint256 _fromIndex
+    );
+
+    /**
+    * @dev redeems aToken for the underlying asset
+    * @param _amount the amount being redeemed
+    **/
+    function redeem(uint256 _amount) external;
+}

--- a/lib/aaveV1/IAaveV1LendingPool.sol
+++ b/lib/aaveV1/IAaveV1LendingPool.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.5.4;
+
+/**
+* @title LendingPool contract as in https://etherscan.io/address/0x017788dded30fdd859d295b90d4e41a19393f423#code
+* @notice Implements the actions of the LendingPool, and exposes accessory methods to fetch the users and reserve data
+* @author Aave
+ **/
+contract IAaveV1LendingPool {
+    /**
+    * @dev emitted on deposit
+    * @param _reserve the address of the reserve
+    * @param _user the address of the user
+    * @param _amount the amount to be deposited
+    * @param _referral the referral number of the action
+    * @param _timestamp the timestamp of the action
+    **/
+    event Deposit(
+        address indexed _reserve,
+        address indexed _user,
+        uint256 _amount,
+        uint16 indexed _referral,
+        uint256 _timestamp
+    );
+
+    /**
+    * @dev deposits The underlying asset into the reserve. A corresponding amount of the overlying asset (aTokens)
+    * is minted.
+    * @param _reserve the address of the reserve
+    * @param _amount the amount to be deposited
+    * @param _referralCode integrators are assigned a referral code and can potentially receive rewards.
+    **/
+    function deposit(address _reserve, uint256 _amount, uint16 _referralCode) external payable;
+
+    // Forbidden function
+    function borrow(
+        address _reserve,
+        uint256 _amount,
+        uint256 _interestRateMode,
+        uint16 _referralCode
+    ) external;
+}

--- a/lib/aaveV1/IUSDCToken.sol
+++ b/lib/aaveV1/IUSDCToken.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.5.4;
+
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @title USDC ERC20 Token
+ *
+ * @dev Interface for the USDC token
+ * https://etherscan.io/address/0xb7277a6e95992041568d9391d09d0122023778a2#code
+ */
+ contract IUSDCToken is IERC20 {
+    /**
+     * @dev Function to add/update a new minter
+     * @param minter The address of the minter
+     * @param minterAllowedAmount The minting amount allowed for the minter
+     * @return True if the operation was successful.
+     */
+    function configureMinter(address minter, uint256 minterAllowedAmount) external returns (bool);
+
+    /**
+     * @dev Function to mint tokens
+     * @param _to The address that will receive the minted tokens.
+     * @param _amount The amount of tokens to mint. Must be less than or equal
+     * to the minterAllowance of the caller.
+     * @return A boolean that indicates if the operation was successful.
+     */
+    function mint(address _to, uint256 _amount) external returns (bool);
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mainnet-fork": "bash ./scripts/start_mainnet_fork.sh",
     "test": "npx truffle test --compile-none",
     "ctest": "npm run compile && npm run test",
-    "test:integration": "npx truffle test --compile-none --network prodFork test-integration/filter-lido.js",
+    "test:integration": "npx truffle test --compile-none --network prodFork test-integration/*",
     "provision:lib:artefacts": "bash ./scripts/provision_lib_artefacts.sh",
     "test:coverage": "COVERAGE=1 node scripts/coverage.js && istanbul check-coverage --statements 93 --branches 85 --functions 91 --lines 93",
     "lint:js": "eslint .",

--- a/scripts/start_mainnet_fork.sh
+++ b/scripts/start_mainnet_fork.sh
@@ -8,4 +8,4 @@ fi
 # Exit script as soon as a command fails.
 set -o errexit
 
-node_modules/.bin/ganache-cli --chainId 1895 --port 3601  --deterministic --fork https://mainnet.infura.io/v3/"$INFURA_KEY"
+node_modules/.bin/ganache-cli --chainId 1895 --port 3601 --gasPrice 0  --deterministic --fork https://mainnet.infura.io/v3/"$INFURA_KEY" --unlock "0xe982615d461dd5cd06575bbea87624fda4e3de17"

--- a/test-integration/filter-aaveV1.js
+++ b/test-integration/filter-aaveV1.js
@@ -28,7 +28,7 @@ const AaveV1ATokenFilter = artifacts.require("AaveV1ATokenFilter");
 const IAaveV1LendingPool = artifacts.require("IAaveV1LendingPool");
 const IAToken = artifacts.require("IAToken");
 const IUSDCToken = artifacts.require("IUSDCToken");
-const TokenPriceRegistry = artifacts.require("TokenPriceRegistry");
+const TokenRegistry = artifacts.require("TokenRegistry");
 
 // Utils
 const utils = require("../utils/utilities.js");
@@ -66,7 +66,7 @@ contract("AaveV1 Filter", (accounts) => {
   let aToken;
   let usdcToken;
   let aUSDCToken;
-  let tokenPriceRegistry;
+  let tokenRegistry;
 
   before(async () => {
     // Wire up AaveV1
@@ -83,7 +83,7 @@ contract("AaveV1 Filter", (accounts) => {
 
     // deploy Argent
     registry = await Registry.new();
-    tokenPriceRegistry = await TokenPriceRegistry.new();
+    tokenRegistry = await TokenRegistry.new();
     dappRegistry = await DappRegistry.new(0);
     guardianStorage = await GuardianStorage.new();
     transferStorage = await TransferStorage.new();
@@ -107,7 +107,7 @@ contract("AaveV1 Filter", (accounts) => {
     await dappRegistry.addDapp(0, aUSDCToken.address, aTokenFilter.address);
     await dappRegistry.addDapp(0, relayer, ZERO_ADDRESS);
     walletImplementation = await BaseWallet.new();
-    manager = new RelayManager(guardianStorage.address, tokenPriceRegistry.address);
+    manager = new RelayManager(guardianStorage.address, tokenRegistry.address);
   });
 
   beforeEach(async () => {

--- a/test-integration/filter-aaveV1.js
+++ b/test-integration/filter-aaveV1.js
@@ -22,8 +22,9 @@ const TransferStorage = artifacts.require("TransferStorage");
 const GuardianStorage = artifacts.require("GuardianStorage");
 const ArgentModule = artifacts.require("ArgentModule");
 const DappRegistry = artifacts.require("DappRegistry");
-const AaveV1Filter = artifacts.require("AaveV1Filter");
-const AaveETHTokenFilter = artifacts.require("AaveETHTokenFilter");
+const AaveV1LendingPoolFilter = artifacts.require("AaveV1LendingPoolFilter");
+const OnlyApproveFilter = artifacts.require("OnlyApproveFilter");
+const AaveV1ATokenFilter = artifacts.require("AaveV1ATokenFilter");
 const IAaveV1LendingPool = artifacts.require("IAaveV1LendingPool");
 const IAToken = artifacts.require("IAToken");
 const TokenPriceRegistry = artifacts.require("TokenPriceRegistry");
@@ -60,11 +61,13 @@ contract("AaveV1 Filter", (accounts) => {
   let uniswapRouter;
 
   let aaveLendingPool;
+  let aaveLendingPoolCore;
   let aToken;
   let tokenPriceRegistry;
 
   before(async () => {
     // Wire up AaveV1
+    aaveLendingPoolCore = "0x3dfd23A6c5E8BbcFc9581d2E864a68feb6a076d3";
     aaveLendingPool = await IAaveV1LendingPool.at("0x398eC7346DcD622eDc5ae82352F02bE94C62d119");
     aToken = await IAToken.at("0x3a3A65aAb0dd2A17E3F1947bA16138cd37d08c04");
 
@@ -90,8 +93,10 @@ contract("AaveV1 Filter", (accounts) => {
       RECOVERY_PERIOD,
       LOCK_PERIOD);
     await registry.registerModule(module.address, ethers.utils.formatBytes32String("ArgentModule"));
-    filter = await AaveV1Filter.new();
-    aaveETHTokenFilter = await AaveETHTokenFilter.new();
+    filter = await AaveV1LendingPoolFilter.new();
+    aaveETHTokenFilter = await AaveV1ATokenFilter.new();
+    const approveFilter = await OnlyApproveFilter.new();
+    await dappRegistry.addDapp(0, aaveLendingPoolCore, approveFilter.address);
     await dappRegistry.addDapp(0, aaveLendingPool.address, filter.address);
     await dappRegistry.addDapp(0, aToken.address, aaveETHTokenFilter.address);
     await dappRegistry.addDapp(0, relayer, ZERO_ADDRESS);

--- a/test-integration/filter-aaveV1.js
+++ b/test-integration/filter-aaveV1.js
@@ -1,0 +1,197 @@
+/* global artifacts */
+
+const ethers = require("ethers");
+const chai = require("chai");
+const BN = require("bn.js");
+const bnChai = require("bn-chai");
+
+const { assert } = chai;
+chai.use(bnChai(BN));
+
+const { expect } = require("chai");
+// UniswapV2
+const UniswapV2Factory = artifacts.require("UniswapV2FactoryMock");
+const UniswapV2Router01 = artifacts.require("UniswapV2Router01Mock");
+const WETH = artifacts.require("WETH9");
+
+// Argent
+const Proxy = artifacts.require("Proxy");
+const BaseWallet = artifacts.require("BaseWallet");
+const Registry = artifacts.require("ModuleRegistry");
+const TransferStorage = artifacts.require("TransferStorage");
+const GuardianStorage = artifacts.require("GuardianStorage");
+const ArgentModule = artifacts.require("ArgentModule");
+const DappRegistry = artifacts.require("DappRegistry");
+const AaveV1Filter = artifacts.require("AaveV1Filter");
+const AaveETHTokenFilter = artifacts.require("AaveETHTokenFilter");
+const IAaveV1LendingPool = artifacts.require("IAaveV1LendingPool");
+const IAToken = artifacts.require("IAToken");
+const TokenPriceRegistry = artifacts.require("TokenPriceRegistry");
+
+// Utils
+const utils = require("../utils/utilities.js");
+const { ETH_TOKEN, initNonce, encodeCalls } = require("../utils/utilities.js");
+
+const AAVE_ETH_TOKEN = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const ZERO_ADDRESS = ethers.constants.AddressZero;
+const SECURITY_PERIOD = 2;
+const SECURITY_WINDOW = 2;
+const LOCK_PERIOD = 4;
+const RECOVERY_PERIOD = 4;
+
+const RelayManager = require("../utils/relay-manager");
+
+contract("AaveV1 Filter", (accounts) => {
+  let manager;
+
+  const owner = accounts[1];
+  const relayer = accounts[4];
+
+  let registry;
+  let transferStorage;
+  let guardianStorage;
+  let module;
+  let wallet;
+  let walletImplementation;
+  let filter;
+  let aaveETHTokenFilter;
+  let dappRegistry;
+
+  let uniswapRouter;
+
+  let aaveLendingPool;
+  let aToken;
+  let tokenPriceRegistry;
+
+  before(async () => {
+    // Wire up AaveV1
+    aaveLendingPool = await IAaveV1LendingPool.at("0x398eC7346DcD622eDc5ae82352F02bE94C62d119");
+    aToken = await IAToken.at("0x3a3A65aAb0dd2A17E3F1947bA16138cd37d08c04");
+
+    // Deploy and fund UniswapV2
+    const uniswapFactory = await UniswapV2Factory.new(ZERO_ADDRESS);
+    const weth = await WETH.new();
+    uniswapRouter = await UniswapV2Router01.new(uniswapFactory.address, weth.address);
+
+    // deploy Argent
+    registry = await Registry.new();
+    tokenPriceRegistry = await TokenPriceRegistry.new();
+    dappRegistry = await DappRegistry.new(0);
+    guardianStorage = await GuardianStorage.new();
+    transferStorage = await TransferStorage.new();
+    module = await ArgentModule.new(
+      registry.address,
+      guardianStorage.address,
+      transferStorage.address,
+      dappRegistry.address,
+      uniswapRouter.address,
+      SECURITY_PERIOD,
+      SECURITY_WINDOW,
+      RECOVERY_PERIOD,
+      LOCK_PERIOD);
+    await registry.registerModule(module.address, ethers.utils.formatBytes32String("ArgentModule"));
+    filter = await AaveV1Filter.new();
+    aaveETHTokenFilter = await AaveETHTokenFilter.new();
+    await dappRegistry.addDapp(0, aaveLendingPool.address, filter.address);
+    await dappRegistry.addDapp(0, aToken.address, aaveETHTokenFilter.address);
+    await dappRegistry.addDapp(0, relayer, ZERO_ADDRESS);
+    walletImplementation = await BaseWallet.new();
+    manager = new RelayManager(guardianStorage.address, tokenPriceRegistry.address);
+  });
+
+  beforeEach(async () => {
+    // create wallet
+    const proxy = await Proxy.new(walletImplementation.address);
+    wallet = await BaseWallet.at(proxy.address);
+    await wallet.init(owner, [module.address]);
+
+    // fund wallet
+    await wallet.send(10000000);
+
+    await initNonce(wallet, module, manager, SECURITY_PERIOD);
+  });
+
+  describe("deposit", () => {
+    it("should allow deposits of ETH on behalf of wallet", async () => {
+      const transactions = encodeCalls([
+        [aaveLendingPool, "deposit", [AAVE_ETH_TOKEN, 1000, ""], 1000]
+      ]);
+
+      const txReceipt = await manager.relay(
+        module,
+        "multiCall",
+        [wallet.address, transactions],
+        wallet,
+        [owner],
+        1,
+        ETH_TOKEN,
+        relayer);
+
+      const { success, error } = utils.parseRelayReceipt(txReceipt);
+      assert.isTrue(success, `deposit failed: "${error}"`);
+
+      const event = await utils.getEvent(txReceipt, aaveLendingPool, "Deposit");
+      assert.equal(event.args._reserve, AAVE_ETH_TOKEN);
+      assert.equal(event.args._user, wallet.address);
+      assert.equal(event.args._amount, 1000);
+
+      const balance = await aToken.balanceOf(wallet.address);
+      expect(balance).to.eq.BN(1000);
+    });
+
+    it("should not allow calling forbidden lending pool methods", async () => {
+      const transactions = encodeCalls([
+        [aaveLendingPool, "borrow", [aToken.address, 10, 0, 0]]
+      ]);
+      const txReceipt = await manager.relay(
+        module,
+        "multiCall",
+        [wallet.address, transactions],
+        wallet,
+        [owner],
+        1,
+        ETH_TOKEN,
+        relayer);
+
+      const { success, error } = utils.parseRelayReceipt(txReceipt);
+      assert.isFalse(success, "borrow should have failed");
+      assert.equal(error, "TM: call not authorised");
+    });
+  });
+
+  describe("redeem", () => {
+    beforeEach(async () => {
+      const transactions = encodeCalls([
+        [aaveLendingPool, "deposit", [AAVE_ETH_TOKEN, 1000, ""], 1000]
+      ]);
+      await manager.relay(
+        module,
+        "multiCall",
+        [wallet.address, transactions],
+        wallet,
+        [owner]);
+    });
+
+    it("should allow redeem to wallet", async () => {
+      const transactions = encodeCalls([
+        [aToken, "redeem", [1000], 0]
+      ]);
+      const txReceipt = await manager.relay(
+        module,
+        "multiCall",
+        [wallet.address, transactions],
+        wallet,
+        [owner],
+        1,
+        ETH_TOKEN,
+        relayer);
+
+      const { success, error } = utils.parseRelayReceipt(txReceipt);
+      assert.isTrue(success, `redeem failed: "${error}"`);
+
+      const event = await utils.getEvent(txReceipt, aToken, "Redeem");
+      assert.equal(event.args._from, wallet.address);
+      assert.equal(event.args._value, 1000);
+    });
+  });
+});

--- a/test/aaveV2.js
+++ b/test/aaveV2.js
@@ -39,7 +39,7 @@ const DECIMALS = 18; // number of decimal for TOKEN_A, TOKEN_B contracts
 
 const RelayManager = require("../utils/relay-manager");
 
-contract("Aave Filter", (accounts) => {
+contract("AaveV2 Filter", (accounts) => {
   let manager;
 
   const infrastructure = accounts[0];

--- a/utils/config-schema.json
+++ b/utils/config-schema.json
@@ -122,6 +122,12 @@
           "properties": {
             "contract": {
               "$ref": "#/definitions/ethaddress"
+            },
+            "lendingPool": {
+              "$ref": "#/definitions/ethaddress"
+            },
+            "aaveToken": {
+              "$ref": "#/definitions/ethaddress"
             }
           }
         },

--- a/utils/config-schema.json
+++ b/utils/config-schema.json
@@ -126,8 +126,12 @@
             "lendingPool": {
               "$ref": "#/definitions/ethaddress"
             },
-            "aaveToken": {
+            "lendingPoolCore": {
               "$ref": "#/definitions/ethaddress"
+            },
+            "aTokens": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/ethaddress" }
             }
           }
         },

--- a/utils/config/development.json
+++ b/utils/config/development.json
@@ -1,1 +1,144 @@
-{"ENS":{"deployOwnRegistry":true,"ensRegistry":"0x27699c3De6Da324ADB6efB565D317e331aAD49fc","domain":"argent.xyz"},"backend":{"accounts":["0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"],"refundCollector":"0xdd32a8E9B39713b5Be04Cafb9C13761Ad92504A6"},"multisig":{"owners":["0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"],"threshold":1,"autosign":true},"settings":{"deployer":{"type":"ganache"},"lockPeriod":480,"timelockPeriod":480,"recoveryPeriod":480,"securityPeriod":240,"securityWindow":240},"CryptoKitties":{"contract":"0x0000000000000000000000000000000000000000"},"defi":{"weth":"0x0000000000000000000000000000000000000000","maker":{"deployOwn":true,"tub":"0x0000000000000000000000000000000000000000","pot":"0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7","jug":"0x0000000000000000000000000000000000000000","migration":"0xd8CE1E76663A3B4FE5316964823072b408e7192E"},"uniswap":{"deployOwn":true,"factory":"0xf695c7dd0EeDa4cC9167795Cbb0ca5139cC04555","v2Router":"0xdFc8050206A480F517E5D22b226b81051c0b1334","unizap":"0x13BdacF2fd86DE458022fA78f8632D594dE6D916"},"compound":{"comptroller":"0x0000000000000000000000000000000000000000","markets":{"0x6b175474e89094c44da98b954eedeac495271d0f":"0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643"}},"paraswap":{"deployOwn":true,"contract":"0xEC0fCd000BEaE049134EFEc813E8f81ad24E38e5","authorisedExchanges":{"Kyber":"0xc1A14410852257E2778e1ebBf98414ca74337774"}},"aave":{"contract":"0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9"},"balancer":{"pools":["0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4","0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5","0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf","0x5b475f2cc362265ddf6a958f3519a35b305d2824","0xf54025af2dc86809be1153c1f20d77adb7e8ecf4","0xe036cce08cf4e23d33bc6b18e53caf532afa8513","0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c","0x454c1d458f9082252750ba42d60fae0887868a3b","0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11","0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5","0xe867be952ee17d2d294f2de62b13b9f4af521e9a","0xe0e6b25b22173849668c85e06bc2ce1f69baff8c","0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1","0xee9a6009b926645d33e10ee5577e9c8d3c95c165","0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d","0x9762c600a39bda3359f50a1fb1f90945cead379d","0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72","0xa5da8cc7167070b62fdcb332ef097a55a68d8824","0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef","0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3","0x7c90a3cd7ec80dd2f633ed562480abbeed3be546","0x834fb8276b4e8a24010e2108fdd7f8417c8922bd","0x6b9887422e2a4ae11577f59ea9c01a6c998752e2","0xa0313dea2ed259edd2d95986cc9046d1a65f649b","0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490","0x41284a88d970d3552a26fae680692ed40b34010c","0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5","0x57755f7dec33320bca83159c26e93751bfd30fbe","0xe010fcda8894c16a8acfef7b37741a760faeddc4"]},"yearn":{"pools":["0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e","0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c","0x37d19d1c4E1fa9DC47bD1eA12f742a0887eDa74a","0xACd43E627e64355f1861cEC6d3a6688B31a6F952","0x2f08119C6f07c006695E079AAFc638b8789FAf18","0xBA2E7Fed597fd0E3e70f5130BcDbbFE06bB94fe1","0x2994529C0652D127b7842094103715ec5299bBed","0x7Ff566E1d69DEfF32a7b244aE7276b9f90e9D0f6","0x9cA85572E6A3EbF24dEDd195623F188735A5179f","0xec0d8D3ED5477106c6D4ea27D90a60e594693C90","0x629c759D1E83eFbF63d84eb3868B564d9521C129","0x881b06da56BB5675c54E4Ed311c21E54C5025298","0x29E240CFD7946BA20895a7a02eDb25C210f9f324"],"wethPools":["0xe1237aA7f535b0CC33Fd973D66cBf830354D16c7"]},"lido":{"contract":"0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84","stETHCurvePool":"0xdc24316b9ae028f1497c275eb9192a3ea0f67022"}},"contracts":{"MultiSigWallet":"0x06362D9Cd157fd80d210360a269B56B4Eb9394b9","WalletFactory":"0x96751c36B358A73fe4D8e74Ed64827d2Ec863f1d","ENSResolver":"0x7e98876e57f330429088b17070B936a50754b0ae","ENSManager":"0xd0e3D320A010f1CfB4b874F9c62b605af6384ae9","TokenPriceProvider":"0xE09C322B745434Fbb2D18c107c13795D4bDF3657","ModuleRegistry":"0x419d56Fa63045e35B3D278a2CFb2f05D47DD0c34","BaseWallet":"0xaaF0CCef0C0C355Ee764B3d36bcCF257C527269B","DexRegistry":"0x3c574B30F493e585FB9054F0baB0d02CE1D4f42b","DappRegistry":"0x1FeC06B5580E1df1fDf2f755c4895F21aF7D7DDb","ArgentWalletDetector":"0x61deDd337EBC195a39b4dc3F6Eacf3DEe3C24b0D","MultiCallHelper":"0xda2bEE201A38Dc8355813b884ca977824811bEA1","TokenRegistry":"0xAB303880C3524ccf05697Ba66fbaB48A59d35f47"},"modules":{"GuardianStorage":"0x54537c7A445372d8Cfdb880d4B3F85191986c6B4","TransferStorage":"0x1cDdB4735C994336AdecE7361746f7808e0Ab648","TokenPriceRegistry":"0xE9809Eb4231EE76963842A4cd8c89bD06dF5F09E","ArgentModule":"0x50eb4b78BCEf5130A6eb66c267f4112560A9D647"},"gitCommit":"4be67eca40e6218c8adf03532b5fa528a3615283"}
+{
+    "ENS": {
+        "deployOwnRegistry": true,
+        "ensRegistry": "0x83aE7312372356d9cC1b61061218B51945596A1A",
+        "domain": "argent.xyz"
+    },
+    "backend": {
+        "accounts": [
+            "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
+        ],
+        "refundCollector": "0xdd32a8E9B39713b5Be04Cafb9C13761Ad92504A6"
+    },
+    "multisig": {
+        "owners": [
+            "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
+        ],
+        "threshold": 1,
+        "autosign": true
+    },
+    "settings": {
+        "deployer": {
+            "type": "ganache"
+        },
+        "lockPeriod": 480,
+        "timelockPeriod": 480,
+        "recoveryPeriod": 480,
+        "securityPeriod": 240,
+        "securityWindow": 240
+    },
+    "CryptoKitties": {
+        "contract": "0x0000000000000000000000000000000000000000"
+    },
+    "defi": {
+        "weth": "0x0000000000000000000000000000000000000000",
+        "maker": {
+            "deployOwn": true,
+            "tub": "0x0000000000000000000000000000000000000000",
+            "pot": "0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7",
+            "jug": "0x0000000000000000000000000000000000000000",
+            "migration": "0xCb0834071Ff7dC5d8672859D29858Cc4d7FA4456"
+        },
+        "uniswap": {
+            "deployOwn": true,
+            "factory": "0xdd8D9D14d2FC73d9657458d937b844581E58c571",
+            "v2Router": "0x90CB112F7E7fd97eda7c3a2D345A641Bef360d00",
+            "unizap": "0xe00d70A79F562Ef4AD9a2B491f90ecEBf8cB7D40"
+        },
+        "compound": {
+            "comptroller": "0x0000000000000000000000000000000000000000",
+            "markets": {
+                "0x6b175474e89094c44da98b954eedeac495271d0f": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643"
+            }
+        },
+        "paraswap": {
+            "deployOwn": true,
+            "contract": "0x13331A9E619b4e016f35f29dF84c1b14675fE33D",
+            "authorisedExchanges": {
+                "Kyber": "0x5722782B7e823cA9Db336c3364A680131F482C08"
+            }
+        },
+        "aave": {
+            "contract": "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9",
+            "lendingPool": "0x9E5C7835E4b13368fd628196C4f1c6cEc89673Fa",
+            "aaveToken": "0x2433A1b6FcF156956599280C3Eb1863247CFE675"
+        },
+        "balancer": {
+            "pools": [
+                "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
+                "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
+                "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
+                "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
+                "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
+                "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
+                "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
+                "0x454c1d458f9082252750ba42d60fae0887868a3b",
+                "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
+                "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
+                "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
+                "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
+                "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
+                "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
+                "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
+                "0x9762c600a39bda3359f50a1fb1f90945cead379d",
+                "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
+                "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
+                "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
+                "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
+                "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
+                "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
+                "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
+                "0xa0313dea2ed259edd2d95986cc9046d1a65f649b",
+                "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
+                "0x41284a88d970d3552a26fae680692ed40b34010c",
+                "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
+                "0x57755f7dec33320bca83159c26e93751bfd30fbe",
+                "0xe010fcda8894c16a8acfef7b37741a760faeddc4"
+            ]
+        },
+        "yearn": {
+            "pools": [
+                "0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e",
+                "0x5dbcF33D8c2E976c6b560249878e6F1491Bca25c",
+                "0x37d19d1c4E1fa9DC47bD1eA12f742a0887eDa74a",
+                "0xACd43E627e64355f1861cEC6d3a6688B31a6F952",
+                "0x2f08119C6f07c006695E079AAFc638b8789FAf18",
+                "0xBA2E7Fed597fd0E3e70f5130BcDbbFE06bB94fe1",
+                "0x2994529C0652D127b7842094103715ec5299bBed",
+                "0x7Ff566E1d69DEfF32a7b244aE7276b9f90e9D0f6",
+                "0x9cA85572E6A3EbF24dEDd195623F188735A5179f",
+                "0xec0d8D3ED5477106c6D4ea27D90a60e594693C90",
+                "0x629c759D1E83eFbF63d84eb3868B564d9521C129",
+                "0x881b06da56BB5675c54E4Ed311c21E54C5025298",
+                "0x29E240CFD7946BA20895a7a02eDb25C210f9f324"
+            ],
+            "wethPools": [
+                "0xe1237aA7f535b0CC33Fd973D66cBf830354D16c7"
+            ]
+        },
+        "lido": {
+            "contract": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+            "stETHCurvePool": "0xdc24316b9ae028f1497c275eb9192a3ea0f67022"
+        }
+    },
+    "contracts": {
+        "MultiSigWallet": "0x6ED5f9899e0975d306dd9AA95A73C52af84D5B7c",
+        "WalletFactory": "0x3d7Eec9C41c7A99489fD17e6B087f9C827b16d3F",
+        "ENSResolver": "0xAE3b465F19Bf5B0B2ef94A1acFd41b412b1D36b2",
+        "ENSManager": "0x5D4aA0caf417ad2BA832671DF9a6a976198D109a",
+        "TokenPriceProvider": "0xE09C322B745434Fbb2D18c107c13795D4bDF3657",
+        "ModuleRegistry": "0x6E62eFEAb443bd1B233C4DF795Da4794511a8907",
+        "BaseWallet": "0x44cAA0c71800eEA0Ec750Ba1A9Ff420cbc393952",
+        "DexRegistry": "0x1a8238498Ee9FF5FAb5375B4dD4386a236C22Ba3",
+        "DappRegistry": "0xae9FddaFfCA85dFAd7E325F6Cea96B1216C60317",
+        "ArgentWalletDetector": "0x7fcFA6cE32bF1F20337bD6AA6805EF28A04e906f",
+        "MultiCallHelper": "0xDE2D1DE7bbc81560cB34421bf562C41B1bB415F2"
+    },
+    "modules": {
+        "GuardianStorage": "0x89c320c75520777AB36f4924cE57c65960370fE1",
+        "TransferStorage": "0xd517fA80Ed2Aa312cB3e8FDD32CB3BBE7D28f5BC",
+        "TokenPriceRegistry": "0xE9809Eb4231EE76963842A4cd8c89bD06dF5F09E",
+        "ArgentModule": "0x69F8a52B97dD0ebC255de83ca25976b0017Fa9ad"
+    },
+    "gitCommit": "ca4cedeb434dc610649c8381b4ff88ef91f563cc"
+}

--- a/utils/config/development.json
+++ b/utils/config/development.json
@@ -1,7 +1,7 @@
 {
     "ENS": {
         "deployOwnRegistry": true,
-        "ensRegistry": "0x83aE7312372356d9cC1b61061218B51945596A1A",
+        "ensRegistry": "0x85cd1F9550CdF662944bEc3E58021f8dbE6fE878",
         "domain": "argent.xyz"
     },
     "backend": {
@@ -37,13 +37,13 @@
             "tub": "0x0000000000000000000000000000000000000000",
             "pot": "0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7",
             "jug": "0x0000000000000000000000000000000000000000",
-            "migration": "0xCb0834071Ff7dC5d8672859D29858Cc4d7FA4456"
+            "migration": "0x70eE878D560D7E17a986872f54B7C58f564B2784"
         },
         "uniswap": {
             "deployOwn": true,
-            "factory": "0xdd8D9D14d2FC73d9657458d937b844581E58c571",
-            "v2Router": "0x90CB112F7E7fd97eda7c3a2D345A641Bef360d00",
-            "unizap": "0xe00d70A79F562Ef4AD9a2B491f90ecEBf8cB7D40"
+            "factory": "0x8c634b72fF5d6A9F6a0281EEF36365E4db8bDF8d",
+            "v2Router": "0x29fa1c214B7242b704063F2Ec52494f4639A9cc3",
+            "unizap": "0xD5746777FE34a3562aD3abc1501629ca0190F23B"
         },
         "compound": {
             "comptroller": "0x0000000000000000000000000000000000000000",
@@ -53,15 +53,18 @@
         },
         "paraswap": {
             "deployOwn": true,
-            "contract": "0x13331A9E619b4e016f35f29dF84c1b14675fE33D",
+            "contract": "0x8E7a8d3CAeEbbe9A92faC4db19424218aE6791a3",
             "authorisedExchanges": {
-                "Kyber": "0x5722782B7e823cA9Db336c3364A680131F482C08"
+                "Kyber": "0x49bC4443E05f7c05A823920CaD1c9EbaAcD7201E"
             }
         },
         "aave": {
             "contract": "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9",
             "lendingPool": "0x9E5C7835E4b13368fd628196C4f1c6cEc89673Fa",
-            "aaveToken": "0x2433A1b6FcF156956599280C3Eb1863247CFE675"
+            "lendingPoolCore": "0x4295ee704716950a4de7438086d6f0fbc0ba9472",
+            "aTokens": [
+                "0x2433A1b6FcF156956599280C3Eb1863247CFE675"
+            ]
         },
         "balancer": {
             "pools": [
@@ -122,23 +125,23 @@
         }
     },
     "contracts": {
-        "MultiSigWallet": "0x6ED5f9899e0975d306dd9AA95A73C52af84D5B7c",
-        "WalletFactory": "0x3d7Eec9C41c7A99489fD17e6B087f9C827b16d3F",
-        "ENSResolver": "0xAE3b465F19Bf5B0B2ef94A1acFd41b412b1D36b2",
-        "ENSManager": "0x5D4aA0caf417ad2BA832671DF9a6a976198D109a",
+        "MultiSigWallet": "0x6FdB1c9e1a1A8beD2EE22a3d5E62CA330ee88ecb",
+        "WalletFactory": "0x4c8cF69bfd3361Dcf1795354afB32Ec4a26212F8",
+        "ENSResolver": "0x72440269630E393d38975Db7fA7Cb4D14e7eC061",
+        "ENSManager": "0x439D0306A0EBD39771781AFB74c1Ae8De29E97Fa",
         "TokenPriceProvider": "0xE09C322B745434Fbb2D18c107c13795D4bDF3657",
-        "ModuleRegistry": "0x6E62eFEAb443bd1B233C4DF795Da4794511a8907",
-        "BaseWallet": "0x44cAA0c71800eEA0Ec750Ba1A9Ff420cbc393952",
-        "DexRegistry": "0x1a8238498Ee9FF5FAb5375B4dD4386a236C22Ba3",
-        "DappRegistry": "0xae9FddaFfCA85dFAd7E325F6Cea96B1216C60317",
-        "ArgentWalletDetector": "0x7fcFA6cE32bF1F20337bD6AA6805EF28A04e906f",
-        "MultiCallHelper": "0xDE2D1DE7bbc81560cB34421bf562C41B1bB415F2"
+        "ModuleRegistry": "0x768b5Faed6DC69816f33377d214ffaf00dcDd0cf",
+        "BaseWallet": "0x748A34eF527CF8FAC65E4Ab6070b42560FF3aE85",
+        "DexRegistry": "0x97bd553f21B175F7CC00819cC6494a7FbA344180",
+        "DappRegistry": "0x3c3d89322de3aC6D5BCBD10801BbB2C68f5AC5f1",
+        "ArgentWalletDetector": "0xc21dc5A1b919088F308e0b02243Aaf64c060Dbd0",
+        "MultiCallHelper": "0x102EB6c9895955Ce780508f1e9ee7Ac2bdd1CE57"
     },
     "modules": {
-        "GuardianStorage": "0x89c320c75520777AB36f4924cE57c65960370fE1",
-        "TransferStorage": "0xd517fA80Ed2Aa312cB3e8FDD32CB3BBE7D28f5BC",
-        "TokenPriceRegistry": "0xE9809Eb4231EE76963842A4cd8c89bD06dF5F09E",
-        "ArgentModule": "0x69F8a52B97dD0ebC255de83ca25976b0017Fa9ad"
+        "GuardianStorage": "0x46E3D301e211d2A2D3148412FCA5788F3182908d",
+        "TransferStorage": "0x40b13914f9886E234E1e00435E76D558FA8cf5ba",
+        "TokenPriceRegistry": "0x9e8efB8C27f3012493ce315974A64CAcDE6f4ccC",
+        "ArgentModule": "0x3b8847C03D86FF38E79f915b23f6531DF3bA01e1"
     },
-    "gitCommit": "ca4cedeb434dc610649c8381b4ff88ef91f563cc"
+    "gitCommit": "188d62e00c11aa3643043cbb16fe2e1b18c622a2"
 }

--- a/utils/versions/development/latest.json
+++ b/utils/versions/development/latest.json
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 {"version":"2.5.0","createdAt":1617098647,"modules":[{"address":"0x50eb4b78BCEf5130A6eb66c267f4112560A9D647","name":"ArgentModule"}],"fingerprint":"0x3780805d"}
+=======
+{"version":"2.5.0","createdAt":1617091870,"modules":[{"address":"0x3b8847C03D86FF38E79f915b23f6531DF3bA01e1","name":"ArgentModule"}],"fingerprint":"0x066c77c5"}
+>>>>>>> 06c43bdf... Fix deployment scripts test


### PR DESCRIPTION
Allow calls to deposit ETH via `LendingPool.deposit(address,uint256,uint16)`

And redeeming aETH via `aToken.redeem(uint256)`

Integration tests working with mainnet contracts:
```
LendingPoolCore: 0x3dfd23A6c5E8BbcFc9581d2E864a68feb6a076d3
LendingPool     0x398eC7346DcD622eDc5ae82352F02bE94C62d119
aETH Token      0x3a3A65aAb0dd2A17E3F1947bA16138cd37d08c04
```

Deployment configuration setup with Ropsten instances:
```
LendingPoolCore: 0x4295ee704716950a4de7438086d6f0fbc0ba9472
LendingPool     0x9E5C7835E4b13368fd628196C4f1c6cEc89673Fa
aETH Token      0x2433A1b6FcF156956599280C3Eb1863247CFE675
```