### PR TITLE
Fix MultiCallHelper verification issues

### DIFF
--- a/contracts/infrastructure/helper/IDappRegistry.sol
+++ b/contracts/infrastructure/helper/IDappRegistry.sol
@@ -1,0 +1,23 @@
+// Copyright (C) 2021  Argent Labs Ltd. <https://argent.xyz>
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.6.12;
+pragma experimental ABIEncoderV2;
+
+interface IDappRegistry {
+    function enabledRegistryIds(address _wallet) external view returns (bytes32);
+    function authorisations(uint8 _registryId, address _dapp) external view returns (bytes32);
+}

--- a/contracts/infrastructure/helper/MultiCallHelper.sol
+++ b/contracts/infrastructure/helper/MultiCallHelper.sol
@@ -1,4 +1,4 @@
-// Copyright (C) 2018  Argent Labs Ltd. <https://argent.xyz>
+// Copyright (C) 2021  Argent Labs Ltd. <https://argent.xyz>
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,13 +18,9 @@ pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../dapp/IFilter.sol";
+import "./IDappRegistry.sol";
 import "../storage/ITransferStorage.sol";
 import "../../modules/common/Utils.sol";
-
-interface IDappRegistry {
-    function enabledRegistryIds(address _wallet) external view returns (bytes32);
-    function authorisations(uint8 _registryId, address _dapp) external view returns (bytes32);
-}
 
 /**
  * @title MultiCallHelper


### PR DESCRIPTION
Split off `IDappRegistry` contract as that was causing issues verifying `MultiCallHelper` contract in EtherScan