### PR TITLE
improve gas efficiency

### DIFF
--- a/contracts/infrastructure/TokenRegistry.sol
+++ b/contracts/infrastructure/TokenRegistry.sol
@@ -51,9 +51,16 @@ contract TokenRegistry is ITokenRegistry, Managed {
 
     function setTradableForTokenList(address[] calldata _tokens, bool[] calldata _tradable) external {
         require(_tokens.length == _tradable.length, "TR: Array length mismatch");
-        for (uint256 i = 0; i < _tokens.length; i++) {
-            require(msg.sender == owner || (!_tradable[i] && managers[msg.sender]), "TR: Unauthorised");
-            isTradable[_tokens[i]] = _tradable[i];
+        if(msg.sender == owner) {
+            for (uint256 i = 0; i < _tokens.length; i++) {
+                isTradable[_tokens[i]] = _tradable[i];
+            }
+        } else {
+            require(managers[msg.sender], "TR: Unauthorised");
+            for (uint256 i = 0; i < _tokens.length; i++) {
+                require(_tradable[i] == false, "TR: Unauthorised operation");
+                isTradable[_tokens[i]] = _tradable[i];
+            }
         }
     }
 }

--- a/test/tokenRegistry.js
+++ b/test/tokenRegistry.js
@@ -47,7 +47,7 @@ contract("TokenRegistry", (accounts) => {
       await tokenRegistry.setTradableForTokenList([tokenAddress], [false], { from: manager });
       const tradable = await tokenRegistry.isTokenTradable(tokenAddress);
       assert.isFalse(tradable);
-      await truffleAssert.reverts(tokenRegistry.setTradableForTokenList([tokenAddress], [true], { from: manager }), "TR: Unauthorised");
+      await truffleAssert.reverts(tokenRegistry.setTradableForTokenList([tokenAddress], [true], { from: manager }), "TR: Unauthorised operation");
     });
 
     it("does not let managers change tradable with invalid array lengths", async () => {


### PR DESCRIPTION
We make `TokenRegistry.setTradableForTokenList`  a bit more gas efficient by extracting from the loop the check on `msg.sender`.