### PR TITLE
Disable balance checking on Gro withdrawals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 tmp
 bin
 .outputParameter
+.secret
 flatten
 flat
 ## Core latex/pdflatex auxiliary files:

--- a/test-integration/filter-gro.js
+++ b/test-integration/filter-gro.js
@@ -88,47 +88,26 @@ contract("Gro Filter", (accounts) => {
       await deposit(isPwrd);
 
       const lpAmount = (await gvt.balanceOf(wallet.address)).divn(new BN(2)).toString();
-      // TODO: remove balance checks on withdrawals if bought token changes
-      const { success, error } = await utils.swapAndCheckBalances({
-        swap: () => withdrawByLPToken(isPwrd, lpAmount),
-        bought: argent.USDT,
-        sold: gvt,
-        wallet,
-      });
+      const { success, error } = await withdrawByLPToken(isPwrd, lpAmount);
       assert.isTrue(success, `withdrawByLPToken failed: "${error}"`);
     });
 
     it("should allow withdrawals (2/4)", async () => {
       await deposit(isPwrd);
       const lpAmount = (await gvt.balanceOf(wallet.address)).divn(new BN(2)).toString();
-      const { success, error } = await utils.swapAndCheckBalances({
-        swap: () => withdrawByStablecoin(isPwrd, lpAmount),
-        bought: argent.DAI,
-        sold: gvt,
-        wallet,
-      });
+      const { success, error } = await withdrawByStablecoin(isPwrd, lpAmount);
       assert.isTrue(success, `withdrawByStablecoin failed: "${error}"`);
     });
 
     it("should allow withdrawals (3/4)", async () => {
       await deposit(isPwrd);
-      const { success, error } = await utils.swapAndCheckBalances({
-        swap: () => withdrawAllSingle(isPwrd),
-        bought: argent.DAI,
-        sold: gvt,
-        wallet,
-      });
+      const { success, error } = await withdrawAllSingle(isPwrd);
       assert.isTrue(success, `withdrawAllSingle failed: "${error}"`);
     });
 
     it("should allow withdrawals (4/4)", async () => {
       await deposit(isPwrd);
-      const { success, error } = await utils.swapAndCheckBalances({
-        swap: () => withdrawAllBalanced(isPwrd),
-        bought: argent.USDT,
-        sold: gvt,
-        wallet,
-      });
+      const { success, error } = await withdrawAllBalanced(isPwrd);
       assert.isTrue(success, `withdrawAllBalanced failed: "${error}"`);
     });
   });


### PR DESCRIPTION
When withdrawing from Gro, we don't know in advance which stable coin we're gonna get so disabling balance checking to keep it simple